### PR TITLE
feat #3: 지도 연결, 디버깅용 영역 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "coverage": "vitest run --coverage",
+    "test": "vitest"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.11",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.1",
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@tailwindcss/vite": "^4.1.11",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/react-router-dom": "^5.3.3",
@@ -30,7 +32,7 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
-    "tailwindcss": "^3.4.17",
+    "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",

--- a/src/component/main/main/map.tsx
+++ b/src/component/main/main/map.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import { useKakaoLoader } from '../../../hooks/main/useKakaoLoader';
+
+const KakaoMap = () => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [selectedPolygon, setSelectedPolygon] = useState<string>('');
+  const loaded = useKakaoLoader();
+
+  useEffect(() => {
+    if (!loaded || !mapRef.current) return;
+
+    const kakao = (window as any).kakao;
+    const map = new kakao.maps.Map(mapRef.current, {
+      center: new kakao.maps.LatLng(37.550701948532236, 127.07428227734258),
+      level: 2,
+    });
+
+    const studentCenterPolygonPath = [
+      new kakao.maps.LatLng(37.54931182018081, 127.07481842704466),
+      new kakao.maps.LatLng(37.54921703581116, 127.07510124208609),
+      new kakao.maps.LatLng(37.5499555833034, 127.07552635196333),
+      new kakao.maps.LatLng(37.550009809360844, 127.0752661269229),
+    ];
+
+    const libraryPolygonPath = [
+      new kakao.maps.LatLng(37.55164364732781, 127.07403424325965),
+      new kakao.maps.LatLng(37.551391158238964, 127.07436783675207),
+      new kakao.maps.LatLng(37.55169727232406, 127.0747246190505),
+      new kakao.maps.LatLng(37.55194075599854, 127.07438535804738),
+    ];
+
+    const aiCenterPolygonPath = [
+      new kakao.maps.LatLng(37.5508231145694, 127.07502363713),
+      new kakao.maps.LatLng(37.55050299725438, 127.07543637164292),
+      new kakao.maps.LatLng(37.55085861214749, 127.07587242067135),
+      new kakao.maps.LatLng(37.55118322872235, 127.07547100729076),
+    ];
+
+    const aiCenterPolygon = new kakao.maps.Polygon({
+      path: aiCenterPolygonPath,
+      strokeWeight: 3,
+      strokeColor: '#39DE2A',
+      strokeOpacity: 0.8,
+      strokeStyle: 'solid',
+      fillColor: '#A2FF99',
+      fillOpacity: 0.7,
+    });
+
+    const studentCenterPolygon = new kakao.maps.Polygon({
+      path: studentCenterPolygonPath,
+      strokeWeight: 3,
+      strokeColor: '#39DE2A',
+      strokeOpacity: 0.8,
+      strokeStyle: 'solid',
+      fillColor: '#A2FF99',
+      fillOpacity: 0.7,
+    });
+
+    const libraryPolygon = new kakao.maps.Polygon({
+      path: libraryPolygonPath,
+      strokeWeight: 3,
+      strokeColor: '#39DE2A',
+      strokeOpacity: 0.8,
+      strokeStyle: 'solid',
+      fillColor: '#A2FF99',
+      fillOpacity: 0.7,
+    });
+
+    studentCenterPolygon.setMap(map);
+    libraryPolygon.setMap(map);
+    aiCenterPolygon.setMap(map);
+
+    const mouseoverOption = {
+      fillColor: '#EFFFED',
+      fillOpacity: 0.8,
+    };
+
+    const mouseoutOption = {
+      fillColor: '#A2FF99',
+      fillOpacity: 0.7,
+    };
+
+    kakao.maps.event.addListener(studentCenterPolygon, 'mouseover', () => {
+      studentCenterPolygon.setOptions(mouseoverOption);
+    });
+
+    kakao.maps.event.addListener(studentCenterPolygon, 'mouseout', () => {
+      studentCenterPolygon.setOptions(mouseoutOption);
+    });
+
+    kakao.maps.event.addListener(studentCenterPolygon, 'mousedown', () => {
+      setSelectedPolygon('studentCenter');
+    });
+
+    kakao.maps.event.addListener(libraryPolygon, 'mousedown', () => {
+      setSelectedPolygon('library');
+    });
+
+    kakao.maps.event.addListener(libraryPolygon, 'mouseover', () => {
+      libraryPolygon.setOptions(mouseoverOption);
+    });
+
+    kakao.maps.event.addListener(libraryPolygon, 'mouseout', () => {
+      libraryPolygon.setOptions(mouseoutOption);
+    });
+
+    kakao.maps.event.addListener(aiCenterPolygon, 'mousedown', () => {
+      setSelectedPolygon('aiCenter');
+    });
+
+    kakao.maps.event.addListener(aiCenterPolygon, 'mouseover', () => {
+      aiCenterPolygon.setOptions(mouseoverOption);
+    });
+
+    kakao.maps.event.addListener(aiCenterPolygon, 'mouseout', () => {
+      aiCenterPolygon.setOptions(mouseoutOption);
+    });
+  }, [loaded]);
+
+  return (
+    <div>
+      <div ref={mapRef} style={{ width: '100%', height: '70vh', marginBottom: '12px' }} />
+      <div>클릭 {selectedPolygon}</div>
+    </div>
+  );
+};
+
+export default KakaoMap;

--- a/src/hooks/main/useKakaoLoader.ts
+++ b/src/hooks/main/useKakaoLoader.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export function useKakaoLoader(): boolean {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    if ((window as any).kakao && (window as any).kakao.maps) {
+      setLoaded(true);
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${import.meta.env.VITE_KAKAO_MAP_API_KEY}&autoload=false&libraries=services`;
+    script.async = true;
+    script.onload = () => {
+      (window as any).kakao.maps.load(() => {
+        setLoaded(true);
+      });
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  return loaded;
+}


### PR DESCRIPTION
<!-- 기능 추가 -->
🔥 구현 기능
---
- 카카오맵 api 가져와서 화면에 표기
- 건물 영역 분리
- package.json 오류 수정

🚧 작업목록
---
- [ ] 카카오맵 api를 useKakaoLoader hook으로 가져와서 연결
- [ ] polygonpath를 이용하여 지도 영역 임시로 분리


<!-- 기능 개선 -->
📝 현재 문제점

- [ ] package.json에서 coverage와 test 가 부적절한 위치에 들어가 있었던 문제 수정

---

- package.json에서 coverage와 test가 devDependencies에 들어가있던 문제가 있었습니다.

🛠️ 해결 방안 
---

- 해당 내용을 `scripts`에 옮겼습니다


🙋‍♂️ 담당자
---
- **백엔드**: 이름
- **프론트엔드**: 강동현

---

package 파일 외에는 제가 담당한 영역 외에는 파일의 수정을 진행하지 않아 구현 내용이 화면에 나타나지 않습니다.
화면을 표기하려면 로컬에서 App.tsx의 내용을 작성해야 합니다.

```javascript

import MainPage from './pages/mainPage';

const App = () => {
  return <MainPage />;
};

export default App;


```


Closes #3