### PR TITLE
Feature/#14 분실물 등록 프로세스 스켈레톤 구현

### DIFF
--- a/src/api/register/index.ts
+++ b/src/api/register/index.ts
@@ -1,0 +1,18 @@
+import type { CategoryFeature } from '../../types/register';
+import type { RegisterFormData } from '../../types/register';
+
+export const fetchCategoryFeatures = async (categoryId: string): Promise<CategoryFeature[]> => {
+  console.log(`[API] Fetching features for category: ${categoryId}`);
+  // 실제로는 categoryId에 따라 다른 질문을 반환
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return [
+    { id: 'q1', question: '무슨 색상인가요?', options: ['검정', '갈색', '흰색', '기타'] },
+    { id: 'q2', question: '무슨 브랜드인가요?', options: ['삼성', '애플', '샤오미', '기타'] },
+  ];
+};
+
+export const postLostItem = async (data: RegisterFormData): Promise<{ success: boolean }> => {
+  // 실제로는 분실물 정보를 서버로 POST 요청
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return { success: true };
+};

--- a/src/component/register/RegisterModal.tsx
+++ b/src/component/register/RegisterModal.tsx
@@ -1,0 +1,115 @@
+import { useRegisterProcess } from '../../hooks/register/useRegisterProcess';
+import { REGISTER_PROCESS_STEPS } from '../../constants/register';
+
+import ProgressBar from '../common/ProgressBar';
+import ResultModal from '../common/ResultModal';
+import Step1_CategorySelect from './steps/Step1_CategorySelect';
+import Step2_DetailForm from './steps/Step2_DetailForm';
+import Step3_Confirm from './steps/Step3_Confirm';
+import CloseIcon from '../common/Icons/CloseIcon';
+import SpinnerIcon from '../common/Icons/SpinnerIcon';
+
+type Props = {
+  onClose: () => void;
+};
+
+const RegisterModal = ({ onClose }: Props) => {
+  // 등록 프로세스의 모든 로직을 담고 있는 커스텀 훅
+  const {
+    currentStep,
+    isLoading,
+    selectedCategory,
+    categoryFeatures,
+    formData,
+    isStep2Valid,
+    resultModal,
+    goToNextStep,
+    goToPrevStep,
+    setSelectedCategory,
+    setFormData,
+    handleRegister,
+  } = useRegisterProcess(onClose);
+
+  const steps = REGISTER_PROCESS_STEPS.STEPS;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      {resultModal.isOpen && <ResultModal {...resultModal} />}
+
+      <div className="relative flex h-[90vh] w-full max-w-4xl flex-col rounded-2xl bg-white p-8 shadow-xl">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:cursor-pointer hover:text-gray-600"
+        >
+          <CloseIcon className="h-6 w-6" />
+        </button>
+
+        <h1 className="text-center text-2xl font-bold text-gray-800">분실물 등록</h1>
+        <ProgressBar steps={steps} currentStep={currentStep} />
+
+        <div className="flex-grow overflow-y-auto pr-2">
+          {currentStep === 1 && (
+            <Step1_CategorySelect
+              selectedCategory={selectedCategory}
+              onSelect={setSelectedCategory}
+            />
+          )}
+          {currentStep === 2 && (
+            <Step2_DetailForm
+              isLoading={isLoading}
+              formData={formData}
+              setFormData={setFormData}
+              categoryFeatures={categoryFeatures}
+            />
+          )}
+          {currentStep === 3 && (
+            <Step3_Confirm
+              selectedCategory={selectedCategory}
+              formData={formData}
+              categoryFeatures={categoryFeatures}
+            />
+          )}
+        </div>
+
+        <div className="mt-auto flex items-center justify-between border-t pt-6">
+          <div>
+            {/* 1단계에서는 '이전' 버튼 숨김 */}
+            {currentStep > 1 && (
+              <button
+                onClick={goToPrevStep}
+                className="rounded-lg bg-gray-200 px-6 py-3 font-bold text-gray-700 hover:cursor-pointer hover:bg-gray-300"
+              >
+                이전
+              </button>
+            )}
+          </div>
+          <div>
+            {/* 마지막 단계가 아닐 경우 '다음' 버튼 표시 */}
+            {currentStep < steps.length ? (
+              <button
+                onClick={goToNextStep}
+                disabled={
+                  (currentStep === 1 && !selectedCategory) || (currentStep === 2 && !isStep2Valid)
+                }
+                className="rounded-lg bg-teal-500 px-6 py-3 font-bold text-white hover:cursor-pointer hover:bg-teal-600 disabled:cursor-not-allowed disabled:bg-gray-300"
+              >
+                다음
+              </button>
+            ) : (
+              // 마지막 단계일 경우 '등록하기' 버튼 표시
+              <button
+                onClick={handleRegister}
+                disabled={isLoading}
+                className="rounded-lg bg-teal-500 px-6 py-3 font-bold text-white hover:cursor-pointer hover:bg-teal-600 disabled:bg-gray-300"
+              >
+                {isLoading ? <SpinnerIcon /> : '등록하기'}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterModal;

--- a/src/component/register/steps/Step1_CategorySelect.tsx
+++ b/src/component/register/steps/Step1_CategorySelect.tsx
@@ -1,0 +1,35 @@
+import type { Category } from '../../../types/register';
+import { CATEGORY_GROUPS } from '../../../constants/register';
+
+const MOCK_CATEGORIES: Category[] = CATEGORY_GROUPS.flatMap((group) => group.categories);
+
+type Props = {
+  selectedCategory: Category | null;
+  onSelect: (category: Category) => void;
+};
+
+const Step1_CategorySelect = ({ selectedCategory, onSelect }: Props) => (
+  <div>
+    <h2 className="mb-4 text-lg font-semibold text-gray-700">카테고리를 선택해주세요</h2>
+    <div className="mb-4 grid grid-cols-3 gap-4 sm:grid-cols-5">
+      {MOCK_CATEGORIES.map((category) => (
+        <button
+          key={category.id}
+          onClick={() => onSelect(category)}
+          className={`flex aspect-square flex-col items-center justify-center rounded-lg border-2 p-4 transition-all ${
+            selectedCategory?.id === category.id
+              ? 'border-teal-500 bg-emerald-50'
+              : 'border-gray-200 bg-white hover:border-gray-400'
+          }`}
+        >
+          <div className="mb-2 h-10 w-10 rounded bg-gray-200">
+            {/* 아이콘이 있다면 여기에 표시 */}
+          </div>
+          <span className="text-sm font-medium text-gray-800">{category.name}</span>
+        </button>
+      ))}
+    </div>
+  </div>
+);
+
+export default Step1_CategorySelect;

--- a/src/component/register/steps/Step1_CategorySelect.tsx
+++ b/src/component/register/steps/Step1_CategorySelect.tsx
@@ -1,23 +1,20 @@
-import type { Category } from '../../../types/register';
 import { CATEGORY_GROUPS } from '../../../constants/register';
 
-const MOCK_CATEGORIES: Category[] = CATEGORY_GROUPS.flatMap((group) => group.categories);
-
 type Props = {
-  selectedCategory: Category | null;
-  onSelect: (category: Category) => void;
+  selectedCategory: string | null;
+  onSelect: (category: string) => void;
 };
 
 const Step1_CategorySelect = ({ selectedCategory, onSelect }: Props) => (
   <div>
     <h2 className="mb-4 text-lg font-semibold text-gray-700">카테고리를 선택해주세요</h2>
     <div className="mb-4 grid grid-cols-3 gap-4 sm:grid-cols-5">
-      {MOCK_CATEGORIES.map((category) => (
+      {CATEGORY_GROUPS.map((group) => (
         <button
-          key={category.id}
-          onClick={() => onSelect(category)}
+          key={group.category}
+          onClick={() => onSelect(group.category)}
           className={`flex aspect-square flex-col items-center justify-center rounded-lg border-2 p-4 transition-all ${
-            selectedCategory?.id === category.id
+            selectedCategory === group.category
               ? 'border-teal-500 bg-emerald-50'
               : 'border-gray-200 bg-white hover:border-gray-400'
           }`}
@@ -25,7 +22,7 @@ const Step1_CategorySelect = ({ selectedCategory, onSelect }: Props) => (
           <div className="mb-2 h-10 w-10 rounded bg-gray-200">
             {/* 아이콘이 있다면 여기에 표시 */}
           </div>
-          <span className="text-sm font-medium text-gray-800">{category.name}</span>
+          <span className="text-sm font-medium text-gray-800">{group.category}</span>
         </button>
       ))}
     </div>

--- a/src/component/register/steps/Step2_DetailForm.tsx
+++ b/src/component/register/steps/Step2_DetailForm.tsx
@@ -1,0 +1,202 @@
+import React, { useRef } from 'react';
+import SpinnerIcon from '../../common/Icons/SpinnerIcon';
+import type { Step2Props } from '../../../types/register';
+
+// 각 섹션을 구분하기 위한 UI 재사용 컴포넌트
+const FormSection: React.FC<{ title: string; children: React.ReactNode }> = ({
+  title,
+  children,
+}) => (
+  <div className="mb-6">
+    <h3 className="mb-3 text-lg font-bold text-gray-800">{title}</h3>
+    <div className="rounded-lg bg-gray-100 p-6">{children}</div>
+  </div>
+);
+
+const Step2_DetailForm = ({
+  isLoading,
+  formData,
+  setFormData,
+  categoryFeatures,
+  selectedArea,
+}: Step2Props) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 입력 필드 변경 핸들러
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // 카테고리 특징 선택 핸들러
+  const handleFeatureChange = (questionId: string, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      featureAnswers: {
+        ...prev.featureAnswers,
+        [questionId]: value,
+      },
+    }));
+  };
+
+  // 이미지 업로드 핸들러
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    const files = Array.from(e.target.files);
+
+    if (formData.images.length + files.length > 3) {
+      return alert('사진은 최대 3장까지 업로드할 수 있습니다.');
+    }
+
+    setFormData((prev) => ({ ...prev, images: [...prev.images, ...files] }));
+  };
+
+  // 이미지 삭제 핸들러
+  const handleRemoveImage = (indexToRemove: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      images: prev.images.filter((_, index) => index !== indexToRemove),
+    }));
+  };
+
+  // 로딩 중일 때는 로딩 스피너 표시
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SpinnerIcon />
+        <span className="ml-2">카테고리 정보를 불러오는 중...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <FormSection title="카테고리 특징">
+        <div className="space-y-4">
+          {categoryFeatures.map((feature) => (
+            <div key={feature.id}>
+              <label htmlFor={feature.id} className="mb-1 block text-sm font-medium text-gray-700">
+                {feature.question}
+              </label>
+              <select
+                id={feature.id}
+                name={feature.id}
+                value={formData.featureAnswers[feature.id] || ''}
+                onChange={(e) => handleFeatureChange(feature.id, e.target.value)}
+                className="w-full rounded-md border-gray-300 p-2 shadow-sm focus:border-teal-500 focus:ring-teal-500"
+              >
+                <option value="" disabled>
+                  선택해주세요
+                </option>
+                {feature.options.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+      </FormSection>
+
+      <FormSection title="위치 상세 정보">
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">선택된 건물</label>
+            <div className="w-full rounded-md border-gray-200 bg-gray-200 p-2 text-gray-600 shadow-inner">
+              {/* 여기서는 선택된 건물이 나와야 하지만 지금은 X */}
+              {selectedArea || '지도에서 건물을 먼저 선택해주세요. (ex: 학술정보원)'}
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="locationDetail"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              상세 위치 (예: 401호, 정문 앞 소파)
+            </label>
+            <input
+              id="locationDetail"
+              type="text"
+              name="locationDetail"
+              value={formData.locationDetail}
+              onChange={handleChange}
+              className="w-full rounded-md border-gray-300 p-2 shadow-sm"
+            />
+          </div>
+        </div>
+      </FormSection>
+
+      <FormSection title="분실물 상세 정보(선택)">
+        <textarea
+          id="description"
+          name="description"
+          value={formData.description}
+          onChange={handleChange}
+          maxLength={500}
+          rows={5}
+          placeholder="분실물에 대한 추가 정보를 입력해주세요. (최대 500자)"
+          className="w-full rounded-md border-gray-300 p-2 shadow-sm"
+        />
+      </FormSection>
+
+      <FormSection title="보관 장소">
+        <input
+          id="storageLocation"
+          type="text"
+          name="storageLocation"
+          value={formData.storageLocation}
+          onChange={handleChange}
+          placeholder="분실물을 보관하고 있는 장소를 입력해주세요"
+          className="w-full rounded-md border-gray-300 p-2 shadow-sm"
+        />
+      </FormSection>
+
+      <FormSection title="사진 업로드">
+        <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-6">
+          <p className="mb-4 text-sm text-gray-500">
+            분실물 사진을 업로드 해주세요 (최소 1장, 최대 3장)
+          </p>
+          <input
+            type="file"
+            multiple
+            accept="image/*"
+            ref={fileInputRef}
+            onChange={handleImageUpload}
+            className="hidden"
+            data-testid="file-input"
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded-lg bg-teal-500 px-6 py-2 font-bold text-white hover:cursor-pointer hover:bg-teal-600"
+          >
+            업로드
+          </button>
+        </div>
+        {formData.images.length > 0 && (
+          <div className="mt-4 grid grid-cols-3 gap-4">
+            {formData.images.map((file, index) => (
+              <div key={index} className="relative aspect-square">
+                <img
+                  src={URL.createObjectURL(file)}
+                  alt={`preview ${index}`}
+                  className="h-full w-full rounded-md object-cover"
+                />
+                <button
+                  onClick={() => handleRemoveImage(index)}
+                  className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white hover:cursor-pointer"
+                >
+                  X
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </FormSection>
+    </div>
+  );
+};
+
+export default Step2_DetailForm;

--- a/src/component/register/steps/Step3_Confirm.tsx
+++ b/src/component/register/steps/Step3_Confirm.tsx
@@ -1,0 +1,86 @@
+import type { RegisterFormData, Category, CategoryFeature } from '../../../types/register';
+
+type Props = {
+  selectedCategory: Category | null;
+  formData: RegisterFormData;
+  categoryFeatures: CategoryFeature[]; // 질문 텍스트를 가져오기 위해 필요
+};
+
+// 각 정보 필드를 보여주기 위한 UI 컴포넌트
+const InfoBox: React.FC<{ title: string; children: React.ReactNode; className?: string }> = ({
+  title,
+  children,
+  className,
+}) => (
+  <div className={`rounded-lg bg-gray-100 p-4 ${className}`}>
+    <h4 className="text-md mb-2 font-bold text-gray-500">{title}</h4>
+    <div className="text-gray-800">{children}</div>
+  </div>
+);
+
+const Step3_Confirm = ({ selectedCategory, formData, categoryFeatures }: Props) => {
+  // 질문 ID를 실제 질문 텍스트로 변환하기 위한 맵 생성
+  const questionMap = new Map(categoryFeatures.map((feat) => [feat.id, feat.question]));
+
+  return (
+    <div>
+      <h2 className="mb-4 text-lg font-semibold text-gray-700">입력 정보를 확인해주세요</h2>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        {/* 왼쪽 */}
+        <div className="space-y-3 lg:col-span-1">
+          <InfoBox title="카테고리">
+            <p className="text-lg font-bold">{selectedCategory?.name || '선택되지 않음'}</p>
+          </InfoBox>
+          <InfoBox title="등록된 사진" className="min-h-[200px]">
+            <div className="grid grid-cols-2 gap-2">
+              {formData.images.map((file, index) => (
+                <img
+                  key={index}
+                  src={URL.createObjectURL(file)}
+                  alt={`confirm ${index}`}
+                  className="aspect-square h-full w-full rounded-md object-cover"
+                />
+              ))}
+            </div>
+          </InfoBox>
+        </div>
+
+        {/* 중앙 */}
+        <div className="space-y-3 lg:col-span-1">
+          <InfoBox title="분실물 특징" className="min-h-[150px]">
+            <ul className="space-y-3 text-sm">
+              {Object.entries(formData.featureAnswers).map(([qid, answer]) => (
+                <li key={qid}>
+                  <span className="text-gray-500">{questionMap.get(qid) || '질문'}: </span>
+                  <span className="font-semibold">{answer}</span>
+                </li>
+              ))}
+            </ul>
+          </InfoBox>
+          <InfoBox title="보관 장소">
+            <p className="text-sm font-semibold">{formData.storageLocation}</p>
+          </InfoBox>
+        </div>
+
+        {/* 오른쪽 */}
+        <div className="space-y-3 lg:col-span-1">
+          <InfoBox title="위치 정보">
+            <p className="mb-2 text-sm text-gray-500">
+              건물: <span className="font-semibold text-black">{formData.building}</span>
+            </p>
+            <p className="text-sm text-gray-500">
+              상세 위치: <span className="font-semibold text-black">{formData.locationDetail}</span>
+            </p>
+          </InfoBox>
+          <InfoBox title="상세 정보">
+            <p className="text-sm font-semibold whitespace-pre-wrap">
+              {formData.description || '입력된 내용이 없습니다.'}
+            </p>
+          </InfoBox>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Step3_Confirm;

--- a/src/constants/register/index.ts
+++ b/src/constants/register/index.ts
@@ -6,65 +6,36 @@ export const REGISTER_PROCESS_STEPS = {
 
 export const CATEGORY_GROUPS: CategoryGroup[] = [
   {
-    groupName: '휴대폰',
-    categories: [
-      { id: 'phone1', name: '휴대폰' },
-      { id: 'phone2', name: '스마트폰' },
-    ],
+    category: '휴대폰',
   },
   {
-    groupName: '가방',
-    categories: [
-      { id: 'bag1', name: '백팩' },
-      { id: 'bag2', name: '토트백' },
-    ],
+    category: '가방',
   },
   {
-    groupName: '결제 카드',
-    categories: [
-      { id: 'card1', name: '신용카드' },
-      { id: 'card2', name: '체크카드' },
-    ],
+    category: '결제 카드',
   },
   {
-    groupName: 'ID 카드',
-    categories: [
-      { id: 'idcard1', name: '주민등록증' },
-      { id: 'idcard2', name: '학생증' },
-    ],
+    category: 'ID 카드',
   },
   {
-    groupName: '기숙사 카드',
-    categories: [{ id: 'dorm1', name: '기숙사 출입카드' }],
+    category: '기숙사 카드',
   },
   {
-    groupName: '지갑',
-    categories: [{ id: 'wallet1', name: '지갑' }],
+    category: '지갑',
   },
   {
-    groupName: '악세서리(금속)',
-    categories: [
-      { id: 'metal1', name: '반지' },
-      { id: 'metal2', name: '목걸이' },
-    ],
+    category: '악세서리(금속)',
   },
   {
-    groupName: '패드',
-    categories: [{ id: 'pad1', name: '태블릿' }],
+    category: '패드',
   },
   {
-    groupName: '노트북',
-    categories: [{ id: 'laptop1', name: '노트북' }],
+    category: '노트북',
   },
   {
-    groupName: '전자 음향기기',
-    categories: [
-      { id: 'audio1', name: '이어폰' },
-      { id: 'audio2', name: '헤드폰' },
-    ],
+    category: '전자 음향기기',
   },
   {
-    groupName: '기타',
-    categories: [{ id: 'etc1', name: '기타' }],
+    category: '기타',
   },
 ];

--- a/src/constants/register/index.ts
+++ b/src/constants/register/index.ts
@@ -5,37 +5,15 @@ export const REGISTER_PROCESS_STEPS = {
 };
 
 export const CATEGORY_GROUPS: CategoryGroup[] = [
-  {
-    category: '휴대폰',
-  },
-  {
-    category: '가방',
-  },
-  {
-    category: '결제 카드',
-  },
-  {
-    category: 'ID 카드',
-  },
-  {
-    category: '기숙사 카드',
-  },
-  {
-    category: '지갑',
-  },
-  {
-    category: '악세서리(금속)',
-  },
-  {
-    category: '패드',
-  },
-  {
-    category: '노트북',
-  },
-  {
-    category: '전자 음향기기',
-  },
-  {
-    category: '기타',
-  },
+  { category: '휴대폰' },
+  { category: '가방' },
+  { category: '결제 카드' },
+  { category: 'ID 카드' },
+  { category: '기숙사 카드' },
+  { category: '지갑' },
+  { category: '악세서리(금속)' },
+  { category: '패드' },
+  { category: '노트북' },
+  { category: '전자 음향기기' },
+  { category: '기타' },
 ];

--- a/src/constants/register/index.ts
+++ b/src/constants/register/index.ts
@@ -1,0 +1,70 @@
+import type { CategoryGroup } from '../../types/register';
+
+export const REGISTER_PROCESS_STEPS = {
+  STEPS: ['카테고리 선택', '상세 정보', '최종 확인'],
+};
+
+export const CATEGORY_GROUPS: CategoryGroup[] = [
+  {
+    groupName: '휴대폰',
+    categories: [
+      { id: 'phone1', name: '휴대폰' },
+      { id: 'phone2', name: '스마트폰' },
+    ],
+  },
+  {
+    groupName: '가방',
+    categories: [
+      { id: 'bag1', name: '백팩' },
+      { id: 'bag2', name: '토트백' },
+    ],
+  },
+  {
+    groupName: '결제 카드',
+    categories: [
+      { id: 'card1', name: '신용카드' },
+      { id: 'card2', name: '체크카드' },
+    ],
+  },
+  {
+    groupName: 'ID 카드',
+    categories: [
+      { id: 'idcard1', name: '주민등록증' },
+      { id: 'idcard2', name: '학생증' },
+    ],
+  },
+  {
+    groupName: '기숙사 카드',
+    categories: [{ id: 'dorm1', name: '기숙사 출입카드' }],
+  },
+  {
+    groupName: '지갑',
+    categories: [{ id: 'wallet1', name: '지갑' }],
+  },
+  {
+    groupName: '악세서리(금속)',
+    categories: [
+      { id: 'metal1', name: '반지' },
+      { id: 'metal2', name: '목걸이' },
+    ],
+  },
+  {
+    groupName: '패드',
+    categories: [{ id: 'pad1', name: '태블릿' }],
+  },
+  {
+    groupName: '노트북',
+    categories: [{ id: 'laptop1', name: '노트북' }],
+  },
+  {
+    groupName: '전자 음향기기',
+    categories: [
+      { id: 'audio1', name: '이어폰' },
+      { id: 'audio2', name: '헤드폰' },
+    ],
+  },
+  {
+    groupName: '기타',
+    categories: [{ id: 'etc1', name: '기타' }],
+  },
+];

--- a/src/hooks/register/useRegisterProcess.ts
+++ b/src/hooks/register/useRegisterProcess.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { fetchCategoryFeatures, postLostItem } from '../../api/register';
+import type { Category, CategoryFeature, RegisterFormData } from '../../types/register';
+
+const INITIAL_FORM_DATA: RegisterFormData = {
+  featureAnswers: {},
+  building: '',
+  locationDetail: '',
+  description: '',
+  storageLocation: '',
+  images: [],
+};
+
+export const useRegisterProcess = (onClose: () => void) => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+  const [categoryFeatures, setCategoryFeatures] = useState<CategoryFeature[]>([]);
+  const [formData, setFormData] = useState<RegisterFormData>(INITIAL_FORM_DATA);
+  const [resultModal, setResultModal] = useState({ isOpen: false });
+
+  // 카테고리 선택 시, 해당 카테고리의 특징 질문들을 API로 가져옴
+  useEffect(() => {
+    if (selectedCategory) {
+      setIsLoading(true);
+      fetchCategoryFeatures(selectedCategory.id)
+        .then(setCategoryFeatures)
+        .finally(() => setIsLoading(false));
+    }
+  }, [selectedCategory]);
+
+  const goToNextStep = () => setCurrentStep((prev) => prev + 1);
+  const goToPrevStep = () => setCurrentStep((prev) => prev - 1);
+
+  // 폼 데이터 유효성 검사
+  const isStep2Valid =
+    Object.keys(formData.featureAnswers).length === categoryFeatures.length &&
+    !!formData.locationDetail &&
+    !!formData.storageLocation &&
+    formData.images.length > 0;
+
+  // 최종 등록 처리
+  const handleRegister = async () => {
+    setIsLoading(true);
+    const submissionData = {
+      categoryId: selectedCategory?.id,
+      ...formData,
+    };
+    try {
+      await postLostItem(submissionData);
+      setResultModal({
+        isOpen: true,
+        status: 'success',
+        title: '등록 완료!',
+        message: '분실물이 성공적으로 등록되었습니다.',
+        buttonText: '홈으로',
+        onConfirm: () => {
+          setResultModal((prev) => ({ ...prev, isOpen: false }));
+          onClose();
+        },
+      });
+    } catch (error) {
+      // 에러 처리
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    currentStep,
+    isLoading,
+    selectedCategory,
+    categoryFeatures,
+    formData,
+    isStep2Valid,
+    resultModal,
+    goToNextStep,
+    goToPrevStep,
+    setSelectedCategory,
+    setFormData,
+    handleRegister,
+  };
+};

--- a/src/tests/register/RegisterModal.test.tsx
+++ b/src/tests/register/RegisterModal.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RegisterModal from '../../component/register/RegisterModal';
+import * as api from '../../api/register';
+
+vi.mock('../../api/register');
+
+describe('RegisterModal 컴포넌트 통합 테스트', () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.spyOn(api, 'fetchCategoryFeatures').mockResolvedValue([]);
+    vi.spyOn(api, 'postLostItem').mockResolvedValue({ success: true });
+    mockOnClose.mockClear();
+  });
+
+  it('1단계에서 카테고리 선택 후 2단계로 이동', async () => {
+    render(<RegisterModal onClose={mockOnClose} />);
+    expect(screen.getByText('카테고리를 선택해주세요')).toBeInTheDocument();
+
+    const categoryButton = screen.getByRole('button', { name: '휴대폰' });
+    fireEvent.click(categoryButton);
+
+    const nextButton = screen.getByRole('button', { name: '다음' });
+    fireEvent.click(nextButton);
+
+    await screen.findByText('카테고리 특징');
+    expect(screen.getByText('카테고리 특징')).toBeInTheDocument();
+  });
+
+  it('1단계에서 카테고리 미선택 시 다음 버튼 비활성화', () => {
+    render(<RegisterModal onClose={mockOnClose} />);
+    const nextButton = screen.getByRole('button', { name: '다음' });
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('2단계에서 이전 버튼 클릭 시 1단계로 돌아감', async () => {
+    render(<RegisterModal onClose={mockOnClose} />);
+    fireEvent.click(screen.getByRole('button', { name: '휴대폰' }));
+    fireEvent.click(screen.getByRole('button', { name: '다음' }));
+
+    await screen.findByText('카테고리 특징');
+    fireEvent.click(screen.getByRole('button', { name: '이전' }));
+    expect(screen.getByText('카테고리를 선택해주세요')).toBeInTheDocument();
+  });
+
+  it('마지막 단계에서 등록하기 버튼 클릭 시 API 호출 및 모달 닫힘', async () => {
+    // Step2에서 사용할 mock categoryFeatures
+    vi.spyOn(api, 'fetchCategoryFeatures').mockResolvedValue([
+      { id: 'color', question: '색상은 무엇인가요?', options: ['빨강', '파랑'] },
+    ]);
+
+    render(<RegisterModal onClose={mockOnClose} />);
+
+    // 1단계 → 카테고리 선택
+    fireEvent.click(screen.getByRole('button', { name: '휴대폰' }));
+    fireEvent.click(screen.getByRole('button', { name: '다음' }));
+
+    // 2단계 로딩 후 카테고리 특징 표시
+    await screen.findByText('카테고리 특징');
+
+    // (1) 카테고리 특징 선택
+    fireEvent.change(screen.getByLabelText('색상은 무엇인가요?'), {
+      target: { value: '빨강' },
+    });
+
+    // (2) 위치 상세 정보 입력
+    fireEvent.change(screen.getByLabelText('상세 위치 (예: 401호, 정문 앞 소파)'), {
+      target: { value: '401호' },
+    });
+
+    // (3) 보관 장소 입력
+    fireEvent.change(screen.getByPlaceholderText('분실물을 보관하고 있는 장소를 입력해주세요'), {
+      target: { value: '사물함' },
+    });
+
+    // (4) 사진 업로드 (mock File 객체 사용)
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    const fileInput = screen.getByTestId('file-input');
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    // "다음" 버튼 클릭 → 3단계로 이동
+    fireEvent.click(screen.getByRole('button', { name: '다음' }));
+
+    // 3단계에서 "등록하기" 버튼 확인 후 클릭
+    const registerButton = await screen.findByRole('button', { name: '등록하기' });
+    fireEvent.click(registerButton);
+
+    // 등록 완료 모달이 뜰 때까지 기다림
+    await screen.findByText('등록 완료!');
+
+    // '홈으로' 버튼 클릭
+    fireEvent.click(screen.getByRole('button', { name: '홈으로' }));
+
+    // API 호출 및 모달 닫힘 확인
+    await waitFor(() => {
+      expect(api.postLostItem).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  it('닫기 버튼 클릭 시 onClose 호출', () => {
+    render(<RegisterModal onClose={mockOnClose} />);
+    fireEvent.click(screen.getByRole('button', { name: '' }));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/src/tests/register/api/register.test.ts
+++ b/src/tests/register/api/register.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchCategoryFeatures, postLostItem } from '../../../api/register';
+
+window.fetch = vi.fn();
+
+describe('등록 API 함수', () => {
+  it('fetchCategoryFeatures는 모의 데이터를 반환해야 합니다', async () => {
+    const features = await fetchCategoryFeatures('phone');
+    expect(Array.isArray(features)).toBe(true);
+    expect(features[0]).toHaveProperty('question', '무슨 색상인가요?');
+  });
+
+  it('postLostItem은 success: true를 반환해야 합니다', async () => {
+    const response = await postLostItem({ test: 'data' });
+    expect(response).toEqual({ success: true });
+  });
+});

--- a/src/tests/register/hooks/useRegisterProcess.test.ts
+++ b/src/tests/register/hooks/useRegisterProcess.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useRegisterProcess } from '../../../hooks/register/useRegisterProcess';
+import * as api from '../../../api/register';
+
+vi.mock('../../../api/register');
+
+describe('useRegisterProcess 훅 테스트', () => {
+  const mockOnClose = vi.fn();
+
+  it('첫 번째 단계(1단계)로 초기화되어야 합니다', () => {
+    const { result } = renderHook(() => useRegisterProcess(mockOnClose));
+    expect(result.current.currentStep).toBe(1);
+    expect(result.current.selectedCategory).toBeNull();
+  });
+
+  it('다음 및 이전 단계로 이동할 수 있어야 합니다', () => {
+    const { result } = renderHook(() => useRegisterProcess(mockOnClose));
+
+    act(() => result.current.goToNextStep());
+    expect(result.current.currentStep).toBe(2);
+
+    act(() => result.current.goToPrevStep());
+    expect(result.current.currentStep).toBe(1);
+  });
+
+  it('카테고리 선택 시, 관련 특징 데이터를 API로 가져와야 합니다', async () => {
+    const mockFeatures = [{ id: 'q1', question: 'Color?', options: ['Red'] }];
+    vi.spyOn(api, 'fetchCategoryFeatures').mockResolvedValue(mockFeatures);
+
+    const { result } = renderHook(() => useRegisterProcess(mockOnClose));
+
+    await act(async () => {
+      result.current.setSelectedCategory({ id: 'cat1', name: 'Phone' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.categoryFeatures).toEqual(mockFeatures);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('최종 등록을 성공적으로 처리해야 합니다', async () => {
+    vi.spyOn(api, 'postLostItem').mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useRegisterProcess(mockOnClose));
+
+    act(() => {
+      result.current.goToNextStep(); // 2단계로 이동
+      result.current.goToNextStep(); // 3단계로 이동
+    });
+
+    await act(async () => {
+      result.current.handleRegister();
+    });
+
+    // resultModal가 업데이트 될 때까지 기다림
+    await waitFor(() => expect(result.current.resultModal.isOpen).toBe(true));
+
+    // onConfirm 호출
+    act(() => {
+      result.current.resultModal.onConfirm?.();
+    });
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/src/tests/register/steps/Step1_CategorySelect.test.tsx
+++ b/src/tests/register/steps/Step1_CategorySelect.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Step1_CategorySelect from '../../../component/register/steps/Step1_CategorySelect';
+
+describe('Step1_CategorySelect 컴포넌트', () => {
+  it('카테고리를 렌더링하고, 클릭 시 onSelect가 호출되어야 합니다', () => {
+    const handleSelect = vi.fn();
+    render(<Step1_CategorySelect selectedCategory={null} onSelect={handleSelect} />);
+
+    const firstCategoryButton = screen.getByRole('button', { name: '휴대폰' });
+    expect(firstCategoryButton).toBeInTheDocument();
+
+    fireEvent.click(firstCategoryButton);
+
+    expect(handleSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'phone1', name: '휴대폰' }),
+    );
+  });
+
+  it('선택된 카테고리에 하이라이트 스타일이 적용되어야 합니다', () => {
+    const selected = { id: 'bag1', name: '백팩' };
+    render(<Step1_CategorySelect selectedCategory={selected} onSelect={() => {}} />);
+
+    const selectedButton = screen.getByRole('button', { name: '백팩' });
+    expect(selectedButton).toHaveClass('border-teal-500');
+  });
+});

--- a/src/tests/register/steps/Step1_CategorySelect.test.tsx
+++ b/src/tests/register/steps/Step1_CategorySelect.test.tsx
@@ -12,16 +12,14 @@ describe('Step1_CategorySelect 컴포넌트', () => {
 
     fireEvent.click(firstCategoryButton);
 
-    expect(handleSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'phone1', name: '휴대폰' }),
-    );
+    expect(handleSelect).toHaveBeenCalledWith('휴대폰');
   });
 
   it('선택된 카테고리에 하이라이트 스타일이 적용되어야 합니다', () => {
-    const selected = { id: 'bag1', name: '백팩' };
+    const selected = '가방';
     render(<Step1_CategorySelect selectedCategory={selected} onSelect={() => {}} />);
 
-    const selectedButton = screen.getByRole('button', { name: '백팩' });
+    const selectedButton = screen.getByRole('button', { name: '가방' });
     expect(selectedButton).toHaveClass('border-teal-500');
   });
 });

--- a/src/tests/register/steps/Step2_DetailForm.test.tsx
+++ b/src/tests/register/steps/Step2_DetailForm.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Step2_DetailForm from '../../../component/register/steps/Step2_DetailForm';
+import type { RegisterFormData, CategoryFeature } from '../../../types/register';
+
+describe('Step2_DetailForm 컴포넌트', () => {
+  let mockSetFormData: ReturnType<typeof vi.fn>;
+  const mockFeatures: CategoryFeature[] = [
+    { id: 'q1', question: '무슨 색상인가요?', options: ['검정', '흰색', '갈색', '기타'] },
+  ];
+  const mockFormData: RegisterFormData = {
+    featureAnswers: {},
+    building: '대양AI센터',
+    locationDetail: '콜라보랩 카운터에 있습니다.',
+    description: '분실물 상세 정보 ----',
+    storageLocation: '학생회관 401호',
+    images: [],
+  };
+
+  beforeEach(() => {
+    mockSetFormData = vi.fn();
+  });
+
+  const setup = (overrides = {}) =>
+    render(
+      <Step2_DetailForm
+        isLoading={false}
+        formData={mockFormData}
+        setFormData={mockSetFormData}
+        categoryFeatures={mockFeatures}
+        selectedArea="대양AI센터"
+        {...overrides}
+      />,
+    );
+
+  it('선택된 건물 표시', () => {
+    setup();
+    expect(screen.getByText('선택된 건물')).toBeInTheDocument();
+    expect(screen.getByText('대양AI센터')).toBeInTheDocument();
+  });
+
+  it('locationDetail, description, storageLocation 입력 시 setFormData 호출', () => {
+    setup();
+
+    const locationInput = screen.getByLabelText(/상세 위치/);
+    fireEvent.change(locationInput, { target: { value: '701호 앞' } });
+    expect(mockSetFormData).toHaveBeenCalled();
+
+    const descriptionInput = screen.getByPlaceholderText(/분실물에 대한 추가 정보/);
+    fireEvent.change(descriptionInput, { target: { value: '새로운 설명' } });
+    expect(mockSetFormData).toHaveBeenCalled();
+
+    const storageInput = screen.getByPlaceholderText(/분실물을 보관하고 있는 장소/);
+    fireEvent.change(storageInput, { target: { value: '학생회관 101호' } });
+    expect(mockSetFormData).toHaveBeenCalled();
+  });
+
+  it('카테고리 특징 select 선택 시 featureAnswers 업데이트', () => {
+    setup();
+    const mockSetFormData = vi.fn();
+
+    mockSetFormData.mockImplementation((updater) => {
+      const newState = typeof updater === 'function' ? updater(mockFormData) : updater;
+      expect(newState.featureAnswers).toEqual({ q1: '검정' });
+    });
+
+    fireEvent.change(screen.getByLabelText(/무슨 색상인가요\?/i), {
+      target: { value: '검정' },
+    });
+  });
+
+  it('이미지 업로드 버튼 클릭 → input 클릭', () => {
+    setup();
+    const uploadButton = screen.getByText('업로드');
+    fireEvent.click(uploadButton);
+    expect(uploadButton).toBeInTheDocument();
+  });
+
+  it('이미지 업로드 및 삭제', () => {
+    setup();
+
+    const file = new File(['dummy'], 'test.png', { type: 'image/png' });
+    const fileInput = screen.getByTestId('file-input') as HTMLInputElement;
+
+    // 이미지 업로드
+    mockSetFormData.mockImplementation((updater) => {
+      const newState = typeof updater === 'function' ? updater(mockFormData) : updater;
+      expect(newState.images).toContain(file);
+    });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    // 이미지 삭제
+    mockSetFormData.mockReset();
+    mockSetFormData.mockImplementation((updater) => {
+      const newState =
+        typeof updater === 'function' ? updater({ ...mockFormData, images: [file] }) : updater;
+      expect(newState.images).toHaveLength(0);
+    });
+
+    const removeButton = screen.getByRole('button');
+    fireEvent.click(removeButton);
+  });
+
+  it('로딩 상태일 때 스피너 표시', () => {
+    setup({ isLoading: true });
+    expect(screen.getByText(/카테고리 정보를 불러오는 중/)).toBeInTheDocument();
+  });
+});

--- a/src/tests/register/steps/Step3_Confirm.test.tsx
+++ b/src/tests/register/steps/Step3_Confirm.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import Step3_Confirm from '../../../component/register/steps/Step3_Confirm';
+import { vi, describe, it, expect } from 'vitest';
+import type { RegisterFormData, CategoryFeature } from '../../../types/register';
+
+const mockCategory = { id: 'phone1', name: '휴대폰' };
+const mockFeatures: CategoryFeature[] = [
+  { id: 'q1', question: '색상', options: [] },
+  { id: 'q2', question: '브랜드', options: [] },
+];
+
+const mockFormData: RegisterFormData = {
+  featureAnswers: { q1: '검정', q2: '삼성' },
+  building: '대양AI센터',
+  locationDetail: '콜라보랩 카운터에 있습니다.',
+  description: '분실물 상세 정보 ----',
+  storageLocation: '학생회관 401호',
+  images: [new File([''], 'image1.png', { type: 'image/png' })],
+};
+
+// URL.createObjectURL 모의 처리
+window.URL.createObjectURL = vi.fn(() => 'mock-url');
+
+describe('Step3_Confirm', () => {
+  it('전달된 모든 확인 정보를 올바르게 렌더링해야 합니다.', () => {
+    render(
+      <Step3_Confirm
+        selectedCategory={mockCategory}
+        formData={mockFormData}
+        categoryFeatures={mockFeatures}
+      />,
+    );
+
+    // 카테고리 이름
+    expect(screen.getByText(mockCategory.name)).toBeInTheDocument();
+
+    // 이미지
+    expect(screen.getByAltText('confirm 0')).toBeInTheDocument();
+    expect(screen.getByAltText('confirm 0')).toHaveAttribute('src', 'mock-url');
+
+    // 분실물 특징
+    expect(screen.getByText('색상:')).toBeInTheDocument();
+    expect(screen.getByText('검정')).toBeInTheDocument();
+    expect(screen.getByText('브랜드:')).toBeInTheDocument();
+    expect(screen.getByText('삼성')).toBeInTheDocument();
+
+    // 보관 장소
+    expect(screen.getByText(mockFormData.storageLocation)).toBeInTheDocument();
+
+    // 위치 정보
+    expect(screen.getByText(/건물:/)).toHaveTextContent(`건물: ${mockFormData.building}`);
+    expect(screen.getByText(/상세 위치:/)).toHaveTextContent(
+      `상세 위치: ${mockFormData.locationDetail}`,
+    );
+
+    // 상세 정보
+    expect(screen.getByText(mockFormData.description)).toBeInTheDocument();
+  });
+
+  it('내용이 없는 필드에 대해 플레이스홀더를 표시해야 합니다.', () => {
+    const emptyFormData: RegisterFormData = {
+      featureAnswers: {},
+      building: '',
+      locationDetail: '',
+      description: '',
+      storageLocation: '',
+      images: [],
+    };
+
+    render(
+      <Step3_Confirm
+        selectedCategory={{ id: 'cat2', name: '지갑' }}
+        formData={emptyFormData}
+        categoryFeatures={mockFeatures}
+      />,
+    );
+
+    // 카테고리 이름은 선택됨
+    expect(screen.getByText('지갑')).toBeInTheDocument();
+
+    // 이미지 없음 처리
+    expect(screen.queryByAltText(/confirm/)).not.toBeInTheDocument();
+
+    // 상세 정보 없음 처리
+    expect(screen.getByText('입력된 내용이 없습니다.')).toBeInTheDocument();
+
+    // 분실물 특징이 없으므로 질문 텍스트만 표시되지 않음
+    Object.values(emptyFormData.featureAnswers).forEach((ans) => {
+      expect(screen.queryByText(ans)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom';
+import { vi, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+window.URL.createObjectURL = vi.fn();
+
+afterEach(() => {
+  cleanup();
+});

--- a/src/types/register/index.ts
+++ b/src/types/register/index.ts
@@ -1,0 +1,33 @@
+export type Category = {
+  id: string;
+  name: string;
+  icon?: string;
+};
+
+export type CategoryFeature = {
+  id: string;
+  question: string;
+  options: string[];
+};
+
+export type RegisterFormData = {
+  featureAnswers: Record<string, string>;
+  building: string;
+  locationDetail: string;
+  description: string;
+  storageLocation: string;
+  images: File[];
+};
+
+export type CategoryGroup = {
+  groupName: string;
+  categories: Category[];
+};
+
+export type Step2Props = {
+  isLoading: boolean;
+  formData: RegisterFormData;
+  setFormData: React.Dispatch<React.SetStateAction<RegisterFormData>>;
+  categoryFeatures: CategoryFeature[];
+  selectedArea: string;
+};

--- a/src/types/register/index.ts
+++ b/src/types/register/index.ts
@@ -20,8 +20,7 @@ export type RegisterFormData = {
 };
 
 export type CategoryGroup = {
-  groupName: string;
-  categories: Category[];
+  category: string;
 };
 
 export type Step2Props = {


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
- closed #14 

## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
### 등록 Modal
- 기본적인 틀은 분실물 찾기 Modal과 같은 구성으로 되어 있습니다.
    - h1 태그와 Progress Bar 컴포넌트 재사용
- 버튼의 위치가 왼쪽 아래에 `이전`, 오른쪽 아래에 `다음`이 위치하고, `이전` 버튼은 1단계에서 보이지 않습니다.

### 분실물 등록 과정은 3단계로 구현
#### 1. 카테고리 선택
- 3 X 5 행렬 형태로 모든 카테고리 + `기타(비귀중품)` 까지 Grid 형태로 구현했습니다.
- `flex-grow`, `overflow-y-auto` 속성을 통해 스크롤 기능 추가했습니다.
- 카테고리 목록은 constants 폴더에서 확인할 수 있습니다.

#### 2. 상세 정보
- 선택된 카테고리에 대하여 서버에서 특징 질문을 GET하여 UI로 보여줍니다.
- 선택된 구역(건물)의 정보는 미리 보여지고, 사용자가 상세 위치를 Input 값으로 받습니다.
- 분실물 상세 정보는 최대 500자까지 작성가능하며, 선택적으로 입력할 수 있습니다.
- 보관 장소는 사용자가 분실물을 보관해둔 장소를 Input 값으로 받습니다.
- 분실물 사진은 최소 1장부터 3장까지 업로드 가능합니다.
- `분실물 상세 정보`를 제외한 4가지 정보를 입력해야 아래의 `다음` 버튼이 활성화 됩니다.

#### 3. 최종 확인
- 사용자가 입력한 분실물 정보에 대해 한 눈에 확인할 수 있는 단계입니다.
- 오른쪽 아래에 `등록하기` 버튼을 클릭함으로써 최종적으로 서버에 분실물 정보를 POST 하여 등록합니다.
- 등록이 완료되면 분실물 찾기 과정처럼 "등록 완료!" 문구가 나오는 ResultModal이 나옵니다.


## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
- 분실물 등록 과정 흐름
- 부족한 UI나 UX에 대한 개인적인 의견
- 3단계 최종 확인 단계에서의 정보 위치 분배


## ✅ 테스트
- [ ] 분실물 등록 Modal에 대한 테스트
- [ ] 등록 3단계 컴포넌트에 대한 테스트
- [ ] 등록 모의 API 함수에 대한 테스트
- [ ] 등록 과정에서 사용되는 커스텀 훅에 대한 테스트