### PR TITLE
feat/#38 라우터 방식으로의 마이그레이션을  위한 초기 경로 설정 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,48 @@
-import MainPage from './pages/mainPage.tsx';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+// 헤더 부분 (카테고리 제외)
+import RootLayout from './layouts/RootLayout';
+// 메인 (카테고리 필터(찾기랑 등록에는 필요 없음 ) + 목록 + 지도)  헤당 쿼리의 스트링 값은 필수가 아님 카테고리가 전체인 경우 전체 구역인 경우 → /?categoryId=&schoolAreaId=&page=
+import MainPage from './pages/main/MainPage';
+// 찾기(Find) -> /find/:lostItemId/*
+import FindLayout from './pages/find/FindLayout'; // 진행 바(진행바 생성을 여기서 해야함 귀중품 비 귀중품 판단해서)와 같은 찾기 단계의 공통 요소, 규칙 검사 단계를 건너띈 경우를 판단
+import FindInfo from './pages/find/FindInfo'; // 정보 확인(물건 정보)
+import FindQuiz from './pages/find/FindQuiz'; // 인증 퀴즈(비귀중품은 FindLayout에서 스킵)
+import FindDetail from './pages/find/FindDetail'; // 상세 정보
+import FindPledge from './pages/find/FindPledge'; // 약관 동의
+// 등록(Register) 플로우 -> /register/*
+import RegisterLayout from './pages/register/RegisterLayout'; // 규칙 검사 단계 건너띈 경우 판단, 진행 바와 같은 공통 요소
+import RegisterCategory from './pages/register/RegisterCategory'; // 1) 카테고리 선택
+import RegisterDetails from './pages/register/RegisterDetails'; // 2) 상세 정보 입력
+import RegisterReview from './pages/register/RegisterReview'; // 3) 최종 확인 등록 버튼 누르고 등록 완료 모달이 뜨고 해당 모달의 확인을 눌러 메인으로 리다이렉트
 
-const App = () => {
-  return <MainPage />;
-};
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* 공통 레이아웃인 헤더를 넣을 부분(카테고리를 제외한 부분) */}
+        <Route element={<RootLayout />}>
+          {/* 메인: (/?categoryId=&schoolAreaId=&page=), 필터/페이지네이션을 쿼리 스트링으로 판단 */}
+          <Route index element={<MainPage />} />
 
-export default App;
+          {/* 찾기: (/find/:lostItemId/*) */}
+          <Route path="find/:lostItemId" element={<FindLayout />}>
+            <Route index element={<Navigate to="info" replace />} />
+            <Route path="info" element={<FindInfo />} />
+            <Route path="quiz" element={<FindQuiz />} />
+            <Route path="detail" element={<FindDetail />} />
+            <Route path="pledge" element={<FindPledge />} />
+          </Route>
+
+          {/* 등록: (/register/*) */}
+          <Route path="register" element={<RegisterLayout />}>
+            <Route index element={<Navigate to="category" replace />} />
+            <Route path="category" element={<RegisterCategory />} />
+            <Route path="details" element={<RegisterDetails />} />
+            <Route path="review" element={<RegisterReview />} />
+          </Route>
+          <Route path="*" element={<MainPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 필요한 제목을 복사 붙여넣기하여 사용해주세요!
		feat: 무슨 부분 기능 추가
		refactor: 무슨 부분 기능 개선
		docs: 무슨 문서 수정
		test: 무슨 테스트 추가
		chore: 잡일, 빌드, 설정 변경
-->

<!-- 기능 추가 -->
🔥 구현 기능
---
- 라우터 방식으로의 마이그레이션을 위한 초기 라우터 경로 설정

**충돌 없이 각각의 페이지를 구현하기 위해서는 다음과 같은 폴더 구조를 가져야 합니다. src 파일 아래 있는 pages 폴더 내부에 main, find, register 폴더를 생성하여 내부에 각각의 페이지를 위한 컴포넌트를 구성합니다. RootLayout에는 카테고리 필터 부분을 제외한 header의 내용이 들어 있어야 합니다. 해당 파일은 src 하위 layouts 폴더 내부에 존재하여야 합니다.**

🚧 작업목록
---
- [ ] App.tsx에 경로 설정
- [ ] 주석으로 각각의 경로에 대한 설명 


<!-- 기능 개선 -->
📝 현재 문제점
---

- 추가적으로 필요한 경로나 잘못된 부분이 있으면 말씀해주시면 감사하겠습니다. 

🛠️ 해결 방안 
---

- 문제를 해결하기 위한 구체적인 방안을 작성해주세요.
- 새로운 기능 또는 개선 사항에 대한 설명을 작성해주세요.

<!-- 주석 해제하고 사용해주세요 (기능추가,기능개선 작성시 작성 하시면됩니다)
⚙️ 작업 내용
---
- 기능 구현에 필요한 작업 항목을 작성합니다.
- 예: API 설계, 프론트엔드 화면 구성 등.
-->


🙋‍♂️ 담당자
---
- **프론트엔드**: 박찬빈
