### PR TITLE
refactor: mainpage관련 컴포넌트 파일 네이밍 변경, pages 폴더의 export 방식 변경

### DIFF
--- a/src/component/main/header/header.tsx
+++ b/src/component/main/header/header.tsx
@@ -1,7 +1,7 @@
 import type { CategoryRadioComponentProps } from '../../../types/main/components';
 import Authentication from './Authentication';
-import CategoryRadio from './categoryRadio';
-import Logo from './logo';
+import CategoryRadio from './CategoryRadio';
+import Logo from './Logo';
 
 const Header = ({
   categories,

--- a/src/component/main/main/list/lostList.tsx
+++ b/src/component/main/main/list/lostList.tsx
@@ -1,5 +1,5 @@
-import LostListItem from './lostListItem';
-import Pagenation from './pagenation';
+import LostListItem from './LostListItem';
+import Pagenation from './Pagenation';
 import type { LostListComponentProps } from '../../../../types/main/components';
 
 export default function LostList({

--- a/src/component/main/main/main.tsx
+++ b/src/component/main/main/main.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import RegisterModal from '../../register/RegisterModal';
 import FindModal from '../../find/FindModal';
-import Map from './map';
-import LostList from './list/lostList';
+import Map from './Map';
+import LostList from './list/LostList';
 import type { MainComponentProps } from '../../../types/main/components';
 import type { LostItemListItem } from '../../../types/lost/lostApi';
 

--- a/src/pages/find/FindDetail.tsx
+++ b/src/pages/find/FindDetail.tsx
@@ -1,3 +1,3 @@
-export function FindDetail() {
+export default function FindDetail() {
   return;
 }

--- a/src/pages/find/FindInfo.tsx
+++ b/src/pages/find/FindInfo.tsx
@@ -1,3 +1,3 @@
-export function FindInfo() {
+export default function FindInfo() {
   return;
 }

--- a/src/pages/find/FindLayout.tsx
+++ b/src/pages/find/FindLayout.tsx
@@ -1,3 +1,3 @@
-export function FindLayout() {
+export default function FindLayout() {
   return;
 }

--- a/src/pages/find/FindPledge.tsx
+++ b/src/pages/find/FindPledge.tsx
@@ -1,3 +1,3 @@
-export function FindPledge() {
+export default function FindPledge() {
   return;
 }

--- a/src/pages/find/FindQuiz.tsx
+++ b/src/pages/find/FindQuiz.tsx
@@ -1,3 +1,3 @@
-export function FindQuiz() {
+export default function FindQuiz() {
   return;
 }

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,3 +1,3 @@
-export function MainPage() {
+export default function MainPage() {
   return;
 }

--- a/src/pages/mainPage.tsx
+++ b/src/pages/mainPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
-import Header from '../component/main/header/header';
-import Main from '../component/main/main/main';
-import RegisterConfirmModal from '../component/main/modal/registerConfirmModal';
+import Header from '../component/main/header/Header';
+import Main from '../component/main/main/Main';
+import RegisterConfirmModal from '../component/main/modal/RegisterConfirmModal';
 import {
   getCategories,
   getLostItemDetail,

--- a/src/pages/register/RegisterCategory.tsx
+++ b/src/pages/register/RegisterCategory.tsx
@@ -1,3 +1,3 @@
-export function RegisterCategory() {
+export default function RegisterCategory() {
   return;
 }

--- a/src/pages/register/RegisterLayout.tsx
+++ b/src/pages/register/RegisterLayout.tsx
@@ -1,3 +1,3 @@
-export function RegisterLayout() {
+export default function RegisterLayout() {
   return;
 }

--- a/src/tests/main/List.test.tsx
+++ b/src/tests/main/List.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import LostList from '../../component/main/main/list/lostList';
-import type { LostItem } from '../../component/main/main/list/lostListItem';
+import LostList from '../../component/main/main/list/LostList';
+import type { LostItem } from '../../component/main/main/list/LostListItem';
 import { describe, test, expect } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 

--- a/src/tests/main/Main.test.tsx
+++ b/src/tests/main/Main.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, cleanup } from '@testing-library/react';
-import Main from '../../component/main/main/main';
-import type { LostItem } from '../../component/main/main/list/lostListItem';
+import Main from '../../component/main/main/Main';
+import type { LostItem } from '../../component/main/main/list/LostListItem';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 

--- a/src/tests/main/RegisterConfirmModal.test.tsx
+++ b/src/tests/main/RegisterConfirmModal.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import RegisterConfirmModal from '../../component/main/modal/registerConfirmModal';
+import RegisterConfirmModal from '../../component/main/modal/RegisterConfirmModal';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 


### PR DESCRIPTION
컴포넌트 네이밍을 변경하는 동시에 pages의 export 방식을 변경했습니다