### PR TITLE
refactor/#52: 라우터 방식으로 mainpage 변경

### DIFF
--- a/src/apis/main/mainApi.tsx
+++ b/src/apis/main/mainApi.tsx
@@ -17,9 +17,13 @@ export const getSchoolAreas = async (): Promise<{ schoolAreas: SchoolArea[] }> =
   return { schoolAreas };
 };
 
-export const getLostItemSummary = async (areaId?: number): Promise<LostItemSummaryRow[]> => {
+export const getLostItemSummary = async (
+  areaId?: number,
+  categoryId?: number,
+): Promise<LostItemSummaryRow[]> => {
   const qs = new URLSearchParams();
   if (areaId) qs.set('areaId', String(areaId));
+  if (categoryId) qs.set('categoryId', String(categoryId));
   const res = await fetch(`/api/lost-items/summary?${qs.toString()}`);
   const data: LostItemSummaryRow[] = await res.json();
   return data;
@@ -35,6 +39,7 @@ export const getLostItemSummaryByCategory = async (
   if (areaId) qs.set('areaId', String(areaId));
   const res = await fetch(`/api/lost-items/summary-by-category?${qs.toString()}`);
   const data: LostItemSummaryRow[] = await res.json();
+  console.log('data', data);
   return data;
 };
 

--- a/src/apis/main/mainApi.tsx
+++ b/src/apis/main/mainApi.tsx
@@ -39,7 +39,6 @@ export const getLostItemSummaryByCategory = async (
   if (areaId) qs.set('areaId', String(areaId));
   const res = await fetch(`/api/lost-items/summary-by-category?${qs.toString()}`);
   const data: LostItemSummaryRow[] = await res.json();
-  console.log('data', data);
   return data;
 };
 

--- a/src/component/main/header/CategoryRadio.tsx
+++ b/src/component/main/header/CategoryRadio.tsx
@@ -1,12 +1,25 @@
-import type { CategoryRadioComponentProps } from '../../../types/main/components';
+import { useContext, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { CategoriesContext, SelectedModeContext } from '../../../contexts/AppContexts';
 
-const CategoryRadio = ({
-  categories,
-  selectedCategoryId,
-  setSelectedCategoryId,
-  selectedMode,
-}: CategoryRadioComponentProps) => {
+const CategoryRadio = () => {
+  const { categories } = useContext(CategoriesContext)!;
+  const { selectedMode } = useContext(SelectedModeContext)!;
+  const [searchParams, setSearchParams] = useSearchParams();
   const tmpCategoryList = [{ categoryId: 0, categoryName: '전체' }, ...categories];
+
+  const selectedCategoryId = Number(searchParams.get('categoryId')) || 0;
+
+  // 카테고리 선택 시 페이지 1로 이동시키는 핸들러
+  const handleSelectCategory = useCallback(
+    (id: number) => {
+      const next = new URLSearchParams(searchParams);
+      next.set('categoryId', String(id));
+      next.set('page', '1');
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
 
   return (
     <>
@@ -24,7 +37,7 @@ const CategoryRadio = ({
                   name="category"
                   value={id}
                   checked={id === selectedCategoryId}
-                  onChange={() => setSelectedCategoryId(id)}
+                  onChange={() => handleSelectCategory(id)}
                   className="peer hidden"
                 />
                 <label

--- a/src/component/main/header/CategoryRadio.tsx
+++ b/src/component/main/header/CategoryRadio.tsx
@@ -3,12 +3,14 @@ import { useSearchParams } from 'react-router-dom';
 import { CategoriesContext, SelectedModeContext } from '../../../contexts/AppContexts';
 
 const CategoryRadio = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const { categories } = useContext(CategoriesContext)!;
   const { selectedMode } = useContext(SelectedModeContext)!;
-  const [searchParams, setSearchParams] = useSearchParams();
-  const tmpCategoryList = [{ categoryId: 0, categoryName: '전체' }, ...categories];
 
   const selectedCategoryId = Number(searchParams.get('categoryId')) || 0;
+
+  const tmpCategoryList = [{ categoryId: 0, categoryName: '전체' }, ...categories]; // msw에서 사용하는 전체 카테고리 추가
 
   // 카테고리 선택 시 페이지 1로 이동시키는 핸들러
   const handleSelectCategory = useCallback(

--- a/src/component/main/header/Header.tsx
+++ b/src/component/main/header/Header.tsx
@@ -6,6 +6,7 @@ import Logo from './Logo';
 
 const Header = () => {
   const { selectedMode } = useContext(SelectedModeContext)!;
+
   return (
     <header className="shrink-0 border-b">
       <div className="flex h-30 items-center justify-between bg-teal-50 px-4 text-black">

--- a/src/component/main/header/Header.tsx
+++ b/src/component/main/header/Header.tsx
@@ -1,14 +1,11 @@
-import type { CategoryRadioComponentProps } from '../../../types/main/components';
+import { useContext } from 'react';
+import { SelectedModeContext } from '../../../contexts/AppContexts';
 import Authentication from './Authentication';
 import CategoryRadio from './CategoryRadio';
 import Logo from './Logo';
 
-const Header = ({
-  categories,
-  selectedCategoryId,
-  setSelectedCategoryId,
-  selectedMode,
-}: CategoryRadioComponentProps) => {
+const Header = () => {
+  const { selectedMode } = useContext(SelectedModeContext)!;
   return (
     <header className="shrink-0 border-b">
       <div className="flex h-30 items-center justify-between bg-teal-50 px-4 text-black">
@@ -17,12 +14,7 @@ const Header = ({
         <Authentication />
       </div>
 
-      <CategoryRadio
-        categories={categories}
-        selectedCategoryId={selectedCategoryId}
-        setSelectedCategoryId={setSelectedCategoryId}
-        selectedMode={selectedMode}
-      />
+      <CategoryRadio />
       {selectedMode === 'register' && (
         <div className="absolute top-0 right-0 left-0 z-40 h-30 bg-gray-500/30" />
       )}

--- a/src/component/main/main/Main.tsx
+++ b/src/component/main/main/Main.tsx
@@ -1,55 +1,31 @@
-import { useNavigate } from 'react-router-dom';
+import { useContext, useCallback } from 'react';
 import Map from './Map';
 import LostList from './list/LostList';
-import type { MainComponentProps } from '../../../types/main/components';
-import type { LostItemListItem } from '../../../types/lost/lostApi';
+import { SelectedModeContext } from '../../../contexts/AppContexts';
 
-const Main = ({
-  pagination,
-  mapSelection,
-  mode,
-  selectedCategoryId,
-  lists,
-  areas,
-  ui,
-}: MainComponentProps) => {
-  const navigate = useNavigate();
+const Main = () => {
+  const { selectedMode, setSelectedMode } = useContext(SelectedModeContext)!;
 
-  const handleOpenFindModal = (item: LostItemListItem) => {
-    navigate(`/find/${item.lostItemId}`);
-  };
+  // 모드 토글 핸들러
+  const toggleMode = useCallback(() => {
+    setSelectedMode(selectedMode === 'register' ? 'append' : 'register');
+  }, [selectedMode, setSelectedMode]);
 
   return (
     <main className="min-h-0 flex-1">
       <div className="grid h-full min-h-0 grid-cols-[380px_1fr]">
         <aside className="relative h-full border-r">
-          <LostList
-            items={lists.items}
-            totalCount={pagination.totalCount}
-            page={pagination.page}
-            setPage={pagination.setPage}
-            onFindButtonClick={handleOpenFindModal}
-          />
+          <LostList />
 
-          {mode.selectedMode === 'register' && (
-            <div className="absolute inset-0 z-10 bg-gray-500/30" />
-          )}
+          {selectedMode === 'register' && <div className="absolute inset-0 z-10 bg-gray-500/30" />}
         </aside>
         <section className="relative h-full min-h-0">
-          <Map
-            setIsRegisterConfirmModalOpen={ui.setIsRegisterConfirmModalOpen}
-            schoolAreas={areas.schoolAreas}
-            setSelectedAreaId={mapSelection.setSelectedAreaId}
-            selectedAreaId={mapSelection.selectedAreaId}
-            lostItemSummary={areas.lostItemSummary}
-            selectedMode={mode.selectedMode}
-            selectedCategoryId={selectedCategoryId}
-          />
+          <Map />
           <button
             className="absolute right-5 bottom-5 z-10 rounded-full bg-teal-600 px-4 py-3 text-sm text-white shadow-lg hover:bg-teal-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-600"
-            onClick={mode.toggleMode}
+            onClick={toggleMode}
           >
-            {mode.selectedMode === 'register' ? '분실물 조회' : '분실물 추가'}
+            {selectedMode === 'register' ? '분실물 조회' : '분실물 추가'}
           </button>
         </section>
       </div>

--- a/src/component/main/main/Main.tsx
+++ b/src/component/main/main/Main.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
-import RegisterModal from '../../register/RegisterModal';
-import FindModal from '../../find/FindModal';
+import { useNavigate } from 'react-router-dom';
 import Map from './Map';
 import LostList from './list/LostList';
 import type { MainComponentProps } from '../../../types/main/components';
@@ -10,22 +8,15 @@ const Main = ({
   pagination,
   mapSelection,
   mode,
+  selectedCategoryId,
   lists,
   areas,
   ui,
-  isRegisterModalOpen,
-  isFindModalOpen,
 }: MainComponentProps) => {
-  const [selectedItemForFind, setSelectedItemForFind] = useState<LostItemListItem | null>(null);
+  const navigate = useNavigate();
 
   const handleOpenFindModal = (item: LostItemListItem) => {
-    setSelectedItemForFind(item);
-    ui.setIsFindModalOpen(true);
-  };
-
-  const handleCloseFindModal = () => {
-    ui.setIsFindModalOpen(false);
-    setSelectedItemForFind(null);
+    navigate(`/find/${item.lostItemId}`);
   };
 
   return (
@@ -52,6 +43,7 @@ const Main = ({
             selectedAreaId={mapSelection.selectedAreaId}
             lostItemSummary={areas.lostItemSummary}
             selectedMode={mode.selectedMode}
+            selectedCategoryId={selectedCategoryId}
           />
           <button
             className="absolute right-5 bottom-5 z-10 rounded-full bg-teal-600 px-4 py-3 text-sm text-white shadow-lg hover:bg-teal-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-600"
@@ -60,17 +52,6 @@ const Main = ({
             {mode.selectedMode === 'register' ? '분실물 조회' : '분실물 추가'}
           </button>
         </section>
-        {isFindModalOpen && selectedItemForFind && (
-          <FindModal item={selectedItemForFind} onClose={handleCloseFindModal} />
-        )}
-
-        {isRegisterModalOpen && (
-          <RegisterModal
-            onClose={() => ui.setIsRegisterModalOpen(false)}
-            schoolAreaId={mapSelection.selectedAreaId}
-            onModeChange={mode.toggleMode}
-          />
-        )}
       </div>
     </main>
   );

--- a/src/component/main/main/Map.tsx
+++ b/src/component/main/main/Map.tsx
@@ -48,7 +48,7 @@ const Map = () => {
     setSearchParams(next, { replace: true });
   };
 
-  // 구역 관리
+  // 구역 가져오기
   const { reset, createRegisterPin } = usePolygons({
     map,
     schoolAreas,
@@ -58,7 +58,7 @@ const Map = () => {
     onSelectArea: updateAreaIdInUrl,
   });
 
-  // 번호 마커 관리
+  // 번호 마커 가져오기
   useNumberedMarkers({
     map,
     schoolAreas,

--- a/src/component/main/main/Map.tsx
+++ b/src/component/main/main/Map.tsx
@@ -12,17 +12,19 @@ import {
 } from '../../../contexts/AppContexts';
 
 const Map = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const { setIsRegisterConfirmModalOpen } = useContext(RegisterConfirmModalContext)!;
   const { schoolAreas } = useContext(SchoolAreasContext)!;
   const { lostItemSummary } = useContext(LostItemSummaryContext)!;
   const { selectedMode } = useContext(SelectedModeContext)!;
-  const [searchParams, setSearchParams] = useSearchParams();
 
   const selectedAreaId = Number(searchParams.get('schoolAreaId')) || 0;
   const selectedCategoryId = Number(searchParams.get('categoryId')) || 0;
 
   const mapRef = useRef<HTMLDivElement>(null);
   const loaded = useLoader();
+
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
 
   useEffect(() => {
@@ -46,6 +48,7 @@ const Map = () => {
     setSearchParams(next, { replace: true });
   };
 
+  // 구역 관리
   const { reset, createRegisterPin } = usePolygons({
     map,
     schoolAreas,
@@ -55,6 +58,7 @@ const Map = () => {
     onSelectArea: updateAreaIdInUrl,
   });
 
+  // 번호 마커 관리
   useNumberedMarkers({
     map,
     schoolAreas,
@@ -63,10 +67,12 @@ const Map = () => {
     selectedCategoryId: selectedCategoryId,
   });
 
+  // 모드 변경 시 마커 초기화
   useEffect(() => {
     reset();
   }, [selectedMode, reset]);
 
+  // 지도 클릭 시 핀 생성 및 모달 열기
   useEffect(() => {
     if (!map) return;
     const kakao = window.kakao;
@@ -85,6 +91,7 @@ const Map = () => {
     return () => kakao.maps.event.removeListener(map, 'click', onMapClick);
   }, [map, selectedMode, setIsRegisterConfirmModalOpen, createRegisterPin, selectedAreaId]);
 
+  // 선택된 구역 정보 가져오기
   const selectedArea = schoolAreas.find((area) => area.id === selectedAreaId);
 
   return (

--- a/src/component/main/main/list/LostList.tsx
+++ b/src/component/main/main/list/LostList.tsx
@@ -6,9 +6,8 @@ import { ItemsContext, TotalCountContext } from '../../../../contexts/AppContext
 export default function LostList() {
   const { items } = useContext(ItemsContext)!;
   const { totalCount } = useContext(TotalCountContext)!;
-  const empty = totalCount === 0;
 
-  if (empty) {
+  if (totalCount === 0) {
     return (
       <div className="px-4 py-6">
         <div className="rounded-2xl border border-teal-200 bg-teal-50 p-6 text-sm text-teal-700">

--- a/src/component/main/main/list/LostList.tsx
+++ b/src/component/main/main/list/LostList.tsx
@@ -1,14 +1,11 @@
+import { useContext } from 'react';
 import LostListItem from './LostListItem';
 import Pagenation from './Pagenation';
-import type { LostListComponentProps } from '../../../../types/main/components';
+import { ItemsContext, TotalCountContext } from '../../../../contexts/AppContexts';
 
-export default function LostList({
-  items,
-  totalCount,
-  page,
-  setPage,
-  onFindButtonClick,
-}: LostListComponentProps) {
+export default function LostList() {
+  const { items } = useContext(ItemsContext)!;
+  const { totalCount } = useContext(TotalCountContext)!;
   const empty = totalCount === 0;
 
   if (empty) {
@@ -29,13 +26,13 @@ export default function LostList({
       <div className="max-h-[61vh] min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 [scrollbar-gutter:stable]">
         <ul className="m-0 list-none space-y-3 p-0 pb-6">
           {items.map((item) => (
-            <LostListItem key={item.lostItemId} item={item} onFindButtonClick={onFindButtonClick} />
+            <LostListItem key={item.lostItemId} item={item} />
           ))}
         </ul>
       </div>
 
       <div className="flex items-center justify-center">
-        <Pagenation page={page} totalCount={totalCount} setPage={setPage} />
+        <Pagenation />
       </div>
     </div>
   );

--- a/src/component/main/main/list/LostListItem.tsx
+++ b/src/component/main/main/list/LostListItem.tsx
@@ -3,6 +3,7 @@ import type {
   ListItemComponentProps,
   StatusBadgeComponentProps,
 } from '../../../../types/main/components';
+import { useNavigate } from 'react-router-dom';
 
 function formatKST(iso: string) {
   try {
@@ -28,12 +29,9 @@ function StatusBadge({ status }: StatusBadgeComponentProps) {
   );
 }
 
-export default function LostListItem({
-  item,
-  className = '',
-  onFindButtonClick,
-}: ListItemComponentProps) {
+export default function LostListItem({ item, className = '' }: ListItemComponentProps) {
   const [imgError, setImgError] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <li className={`relative rounded-2xl bg-white p-4 shadow-sm ring-1 ring-black/5 ${className}`}>
@@ -67,7 +65,7 @@ export default function LostListItem({
 
           <button
             className="absolute right-3 bottom-3 rounded-lg border border-teal-200 px-2.5 py-1 text-xs text-teal-700 hover:bg-teal-50"
-            onClick={() => onFindButtonClick(item)}
+            onClick={() => navigate(`/find/${item.lostItemId}`)}
           >
             분실물 찾기
           </button>

--- a/src/component/main/main/list/LostListItem.tsx
+++ b/src/component/main/main/list/LostListItem.tsx
@@ -5,6 +5,7 @@ import type {
 } from '../../../../types/main/components';
 import { useNavigate } from 'react-router-dom';
 
+// 분실물 등록 시간 포맷팅
 function formatKST(iso: string) {
   try {
     return new Date(iso).toLocaleDateString('ko-KR', {
@@ -17,6 +18,7 @@ function formatKST(iso: string) {
   }
 }
 
+// 분실물 상태 배지
 function StatusBadge({ status }: StatusBadgeComponentProps) {
   const isFound = status === 'found';
   const badgeClass = isFound
@@ -29,8 +31,10 @@ function StatusBadge({ status }: StatusBadgeComponentProps) {
   );
 }
 
-export default function LostListItem({ item, className = '' }: ListItemComponentProps) {
+export default function LostListItem({ item, className }: ListItemComponentProps) {
+  // 이미지 로딩 에러 처리
   const [imgError, setImgError] = useState(false);
+
   const navigate = useNavigate();
 
   return (

--- a/src/component/main/main/list/Pagenation.tsx
+++ b/src/component/main/main/list/Pagenation.tsx
@@ -3,8 +3,10 @@ import { useSearchParams } from 'react-router-dom';
 import { TotalCountContext } from '../../../../contexts/AppContexts';
 
 const Pagenation = () => {
-  const { totalCount } = useContext(TotalCountContext)!;
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const { totalCount } = useContext(TotalCountContext)!;
+
   const page = Number(searchParams.get('page')) || 1;
 
   // 페이지 이동 설정 핸들러

--- a/src/component/main/main/list/Pagenation.tsx
+++ b/src/component/main/main/list/Pagenation.tsx
@@ -1,6 +1,18 @@
-import type { PaginationComponentProps } from '../../../../types/main/components';
+import { useContext } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { TotalCountContext } from '../../../../contexts/AppContexts';
 
-const Pagenation = ({ page, totalCount, setPage }: PaginationComponentProps) => {
+const Pagenation = () => {
+  const { totalCount } = useContext(TotalCountContext)!;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const page = Number(searchParams.get('page')) || 1;
+
+  // 페이지 이동 설정 핸들러
+  const setPage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(p));
+    setSearchParams(next, { replace: true });
+  };
   return (
     <div className="fixed bottom-0 flex justify-center gap-2 rounded-full bg-white/90 px-4 py-2 backdrop-blur">
       <button

--- a/src/component/main/modal/RegisterConfirmModal.tsx
+++ b/src/component/main/modal/RegisterConfirmModal.tsx
@@ -1,17 +1,22 @@
-import type { ModalComponentProps } from '../../../types/main/components';
+import { useContext } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { RegisterConfirmModalContext } from '../../../contexts/AppContexts';
 
-const RegisterConfirmModal = ({
-  isOpen,
-  onConfirm,
-  onCancel,
-  setIsRegisterConfirmModalOpen,
-}: ModalComponentProps) => {
-  if (!isOpen) return null;
+const RegisterConfirmModal = () => {
+  const { isRegisterConfirmModalOpen, setIsRegisterConfirmModalOpen } = useContext(
+    RegisterConfirmModalContext,
+  )!;
+
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const selectedAreaId = Number(searchParams.get('schoolAreaId')) || 0;
 
   const handleCancel = () => {
     setIsRegisterConfirmModalOpen(false);
-    onCancel();
   };
+
+  if (!isRegisterConfirmModalOpen) return null;
 
   return (
     <div
@@ -26,7 +31,10 @@ const RegisterConfirmModal = ({
         <div className="flex justify-end gap-2">
           <button
             className="rounded-lg bg-teal-600 px-4 py-2 text-white hover:bg-teal-700"
-            onClick={onConfirm}
+            onClick={() => {
+              setIsRegisterConfirmModalOpen(false);
+              navigate(`/register/${selectedAreaId}`);
+            }}
           >
             등록
           </button>

--- a/src/hooks/map/usePolygons.ts
+++ b/src/hooks/map/usePolygons.ts
@@ -127,6 +127,16 @@ export function usePolygons({
     polysRef.current = polys;
     polyByIdRef.current = byId;
 
+    // 초기 로드/새로고침 시 현재 selectedAreaId에 맞춰 선택 상태 적용
+    if (selectedAreaId) {
+      const poly = byId.get(selectedAreaId) || null;
+      if (poly) {
+        polysRef.current.forEach((p) => p.setOptions(BASE_STYLE));
+        poly.setOptions(SELECTED_STYLE);
+        selectedPolygonRef.current = poly;
+      }
+    }
+
     return () => {
       handlers.forEach(({ target, type, handler }) =>
         kakao.maps.event.removeListener(target, type, handler),

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -71,7 +71,7 @@ const MainPage = () => {
   useEffect(() => {
     const fetchLostItemSummary = async () => {
       try {
-        const data = await getLostItemSummary(selectedAreaId, selectedCategoryId || undefined);
+        const data = await getLostItemSummary(selectedAreaId, selectedCategoryId);
         setLostItemSummary(data);
       } catch (error) {
         console.error('분실물 요약 데이터 가져오기 실패:', error);

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,77 +1,34 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useContext } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import Header from '../../component/main/header/Header';
 import Main from '../../component/main/main/Main';
-import RegisterConfirmModal from '../../component/main/modal/RegisterConfirmModal';
 import {
   getCategories,
   getLostItemDetail,
   getLostItemSummary,
   getSchoolAreas,
 } from '../../apis/main/mainApi';
-import type { SchoolArea } from '../../types/map/map';
-import type { Category, LostItemListItem, LostItemSummaryRow } from '../../types/lost/lostApi';
+import {
+  CategoriesContext,
+  ItemsContext,
+  SchoolAreasContext,
+  TotalCountContext,
+  LostItemSummaryContext,
+} from '../../contexts/AppContexts';
+import RegisterConfirmModal from '../../component/main/modal/RegisterConfirmModal';
 
 const MainPage = () => {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [items, setItems] = useState<LostItemListItem[]>([]);
+  const [searchParams] = useSearchParams();
+  const { setCategories } = useContext(CategoriesContext)!;
+  const { setItems } = useContext(ItemsContext)!;
+  const { setSchoolAreas } = useContext(SchoolAreasContext)!;
+  const { setTotalCount } = useContext(TotalCountContext)!;
+  const { setLostItemSummary } = useContext(LostItemSummaryContext)!;
 
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number>(0);
-  const [selectedAreaId, setSelectedAreaId] = useState<number>(0);
-
-  const [schoolAreas, setSchoolAreas] = useState<SchoolArea[]>([]);
-
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [page, setPage] = useState<number>(1);
-
-  const [selectedMode, setSelectedMode] = useState<'register' | 'append'>('append');
-  const [lostItemSummary, setLostItemSummary] = useState<LostItemSummaryRow[]>([]);
-  const [isRegisterConfirmModalOpen, setIsRegisterConfirmModalOpen] = useState(false);
-
-  // 카테고리별 요약 데이터 계산
-  const getCategorySummary = useCallback(
-    async (categoryId: number) => {
-      if (categoryId === 0) {
-        // 전체 카테고리인 경우 기존 summary 사용
-        return lostItemSummary;
-      }
-
-      if (schoolAreas.length === 0) {
-        return [];
-      }
-
-      try {
-        // 각 학교 구역별로 해당 카테고리의 개수를 계산
-        const categorySummaryPromises = schoolAreas.map(async (area) => {
-          const { total } = await getLostItemDetail(1, 1000, categoryId, area.id);
-          return {
-            schoolAreaId: area.id,
-            count: total,
-          };
-        });
-
-        const categorySummary = await Promise.all(categorySummaryPromises);
-        return categorySummary;
-      } catch (error) {
-        console.error('Failed to fetch category summary:', error);
-        return [];
-      }
-    },
-    [schoolAreas, lostItemSummary],
-  );
-
-  const [categorySummary, setCategorySummary] = useState<LostItemSummaryRow[]>([]);
-
-  // 카테고리 변경 시 카테고리별 요약 데이터 업데이트
-  useEffect(() => {
-    const updateCategorySummary = async () => {
-      const summary = await getCategorySummary(selectedCategoryId);
-      setCategorySummary(summary);
-    };
-    updateCategorySummary();
-  }, [selectedCategoryId, getCategorySummary]);
+  const selectedCategoryId = Number(searchParams.get('categoryId')) || 0;
+  const selectedAreaId = Number(searchParams.get('schoolAreaId')) || 0;
+  const page = Number(searchParams.get('page')) || 1;
 
   // lostItemId가 존재하면 찾기 프로세스로 라우팅
   useEffect(() => {
@@ -81,21 +38,7 @@ const MainPage = () => {
     }
   }, [searchParams, navigate]);
 
-  // 상태 → 메인 쿼리스트링 동기화
-  useEffect(() => {
-    const next = new URLSearchParams();
-    next.set('categoryId', String(selectedCategoryId));
-    next.set('schoolAreaId', String(selectedAreaId));
-    next.set('page', String(page));
-    setSearchParams(next, { replace: true });
-  }, [selectedCategoryId, selectedAreaId, page, setSearchParams]);
-
-  // 모드 토글 핸들러: 등록/찾기 모드 전환
-  const toggleMode = () => {
-    setSelectedMode(selectedMode === 'register' ? 'append' : 'register');
-  };
-
-  // 카테고리 데이터 가져오기
+  // 카테고리 데이터 가져오기 (context 상태를 채움)
   useEffect(() => {
     const fetchCategories = async () => {
       const categories = await getCategories();
@@ -104,7 +47,7 @@ const MainPage = () => {
     fetchCategories();
   }, []);
 
-  // 학교 구역 데이터 가져오기
+  // 학교 구역 데이터 가져오기 (context 상태를 채움)
   useEffect(() => {
     const fetchSchoolAreas = async () => {
       const data = await getSchoolAreas();
@@ -114,7 +57,7 @@ const MainPage = () => {
     fetchSchoolAreas();
   }, []);
 
-  // 분실물 목록 데이터 가져오기 (페이지, 카테고리, 구역 변경 시)
+  // 분실물 목록 데이터 가져오기 (페이지, 카테고리, 구역 변경 시) → context 상태를 채움
   useEffect(() => {
     (async () => {
       const { items, total } = await getLostItemDetail(page, 5, selectedCategoryId, selectedAreaId);
@@ -123,7 +66,7 @@ const MainPage = () => {
     })();
   }, [page, selectedCategoryId, selectedAreaId]);
 
-  // 선택된 구역의 분실물 요약 데이터 가져오기
+  // 선택된 구역의 분실물 요약 데이터 가져오기 → context 상태를 채움
   useEffect(() => {
     const fetchLostItemSummary = async () => {
       try {
@@ -140,36 +83,11 @@ const MainPage = () => {
   return (
     <>
       <div className="flex h-screen flex-col">
-        <Header
-          categories={categories}
-          selectedCategoryId={selectedCategoryId}
-          setSelectedCategoryId={setSelectedCategoryId}
-          selectedMode={selectedMode}
-        />
-        <Main
-          pagination={{ page, setPage, totalCount: totalCount }}
-          mapSelection={{
-            selectedAreaId,
-            setSelectedAreaId,
-          }}
-          mode={{ selectedMode, toggleMode }}
-          selectedCategoryId={selectedCategoryId}
-          lists={{ items, categories }}
-          areas={{ schoolAreas, lostItemSummary: categorySummary }}
-          ui={{ setIsRegisterConfirmModalOpen }}
-        />
+        <Header />
+        <Main />
       </div>
 
-      <RegisterConfirmModal
-        setIsRegisterConfirmModalOpen={setIsRegisterConfirmModalOpen}
-        isOpen={isRegisterConfirmModalOpen}
-        onConfirm={() => {
-          setIsRegisterConfirmModalOpen(false);
-          // 등록은 페이지 방식으로 전환
-          navigate(`/register/${selectedAreaId}`);
-        }}
-        onCancel={() => setIsRegisterConfirmModalOpen(false)}
-      />
+      <RegisterConfirmModal />
     </>
   );
 };

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -20,6 +20,7 @@ import RegisterConfirmModal from '../../component/main/modal/RegisterConfirmModa
 const MainPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+
   const { setCategories } = useContext(CategoriesContext)!;
   const { setItems } = useContext(ItemsContext)!;
   const { setSchoolAreas } = useContext(SchoolAreasContext)!;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -67,19 +67,19 @@ const MainPage = () => {
     })();
   }, [page, selectedCategoryId, selectedAreaId]);
 
-  // 선택된 구역의 분실물 요약 데이터 가져오기 → context 상태를 채움
+  // 선택된 구역/카테고리의 분실물 요약 데이터 가져오기 → context 상태를 채움 (단일 호출)
   useEffect(() => {
     const fetchLostItemSummary = async () => {
       try {
-        const data = await getLostItemSummary(selectedAreaId);
+        const data = await getLostItemSummary(selectedAreaId, selectedCategoryId || undefined);
         setLostItemSummary(data);
       } catch (error) {
-        console.error('Failed to fetch lost item summary:', error);
+        console.error('분실물 요약 데이터 가져오기 실패:', error);
         setLostItemSummary([]);
       }
     };
     fetchLostItemSummary();
-  }, [selectedAreaId]);
+  }, [selectedAreaId, selectedCategoryId, setLostItemSummary]);
 
   return (
     <>

--- a/src/types/main/components.d.ts
+++ b/src/types/main/components.d.ts
@@ -26,7 +26,6 @@ export type ButtonComponentProps = {
 export type ListItemComponentProps = {
   item: LostItemListItem;
   className?: string;
-  onFindButtonClick: (item: LostItemListItem) => void;
 };
 
 export type PaginationComponentProps = {
@@ -40,7 +39,6 @@ export type LostListComponentProps = {
   totalCount: number;
   page: number;
   setPage: (page: number) => void;
-  onFindButtonClick: (item: LostItemListItem) => void;
 };
 
 export type MainComponentProps = {

--- a/src/types/main/components.d.ts
+++ b/src/types/main/components.d.ts
@@ -14,7 +14,6 @@ export type ModalComponentProps = {
   onConfirm: () => void;
   onCancel: () => void;
   setIsRegisterConfirmModalOpen: (b: boolean) => void;
-  setIsRegisterModalOpen: (b: boolean) => void;
 };
 
 export type ButtonComponentProps = {
@@ -48,6 +47,7 @@ export type MainComponentProps = {
   pagination: PaginationState;
   mapSelection: MapSelectionState;
   mode: ModeState;
+  selectedCategoryId: number;
   lists: {
     items: LostItemListItem[];
     categories: Category[];
@@ -58,11 +58,7 @@ export type MainComponentProps = {
   };
   ui: {
     setIsRegisterConfirmModalOpen: (b: boolean) => void;
-    setIsRegisterModalOpen: (b: boolean) => void;
-    setIsFindModalOpen: (b: boolean) => void;
   };
-  isRegisterModalOpen: boolean;
-  isFindModalOpen: boolean;
 };
 
 export type MapComponentProps = {
@@ -72,6 +68,7 @@ export type MapComponentProps = {
   schoolAreas: SchoolArea[];
   lostItemSummary: LostItemSummaryRow[];
   selectedMode: lostItemMode;
+  selectedCategoryId: number;
 };
 
 export type StatusBadgeComponentProps = {


### PR DESCRIPTION
# 🔥 구현 기능 (기능/로직 중심)

## 상태 관리
- 라우팅 중심 상태 관리 마이그레이션: URL 쿼리(`categoryId`, `schoolAreaId`, `page`, `lostItemId`)를 사용하도록 변경
- 컨텍스트는 서버 데이터(`categories`, `items`, `totalCount`, `lostItemSummary`)와 UI 상태(`mode`, `isRegisterConfirmModalOpen`)만 보관 - 전역상태 도입 논의 필요
- 카테고리/지역 변경 시 `page=1` 자동 리셋
- 데이터 로딩은 MainPage에서 수행

## 지도 로직

- 폴리곤 클릭 → URL의 `schoolAreaId` 갱신(+ `page=1`)
- 지도 빈 곳 클릭  
  - 조회 모드: `schoolAreaId=0`으로 초기화  
  - 등록 모드: `schoolAreaId=0` + 클릭 위치에 핀 생성 + 등록 확인 모달 오픈
- `useNumberedMarkers`가 컨텍스트의 `lostItemSummary`로 숫자 마커 렌더



---

# 🚧 작업목록
- [x] 라우팅 마이그래이션(메인/찾기 연결/등록 연결)
- [x] 모달 상태 제거(확인 모달만 유지), 페이지 전환 기반으로 정리
- [x] props drilling 제거(하위는 컨텍스트/URL 직접 구독)
- [x] `getLostItemSummary(areaId, categoryId)`로 API 확장
- [x] 카테고리/지역 변경 시 `page=1` 리셋
- [x] 폴리곤 최초 생성 시 선택 하이라이트 유지(새로고침시에도 적용)

---

# 📝 현재 문제점
- 지도/목록 데이터가 URL에 의존하므로 빠른 연속 변경 시 서버 호출이 많아질 수 있을 것 같습니다.

---

# 🛠️ 해결 방안
- 최적화/ 백엔드와의 논의 필요


---

👨‍💻 **담당자**: 프론트엔드 강동현  
Close #52