### PR TITLE
feature/#61 URL을 통해 분실물 정보에 대한 접근을 위한 공개 정보 위한 API 추가(MSW)

### DIFF
--- a/src/mocks/handlers/lostItems.handlers.ts
+++ b/src/mocks/handlers/lostItems.handlers.ts
@@ -1,5 +1,10 @@
 import { http, HttpResponse } from 'msw';
-import { getSummary, getDetail, getEtcDetail } from '../selectors/lostItems.selectors';
+import {
+  getSummary,
+  getDetail,
+  getEtcDetail,
+  getPublicById,
+} from '../selectors/lostItems.selectors';
 import { toInt } from '../utils/toInt';
 import { createLostItemFromFormData } from '../selectors/register.selectors';
 
@@ -35,7 +40,8 @@ export const lostItemsHandlers = [
 
     return HttpResponse.json(data);
   }),
-  http.get('/api/lost-items/:id', ({ params }) => {
+
+  http.get('/api/lost-items/:id/detail', ({ params }) => {
     const id = toInt(params.id);
     if (!id) return HttpResponse.json({ error: 'invalid id' }, { status: 400 });
 
@@ -50,6 +56,28 @@ export const lostItemsHandlers = [
 
     return HttpResponse.json(result, { status: 200 });
   }),
+
+  http.get('/api/lost-items/:id', ({ params }) => {
+    const id = toInt(params.id);
+    if (!id) {
+      return HttpResponse.json({ error: 'invalid id' }, { status: 400 });
+    }
+
+    const result = getPublicById(id);
+
+    if ('error' in result) {
+      if (result.error === 'NOT_FOUND') {
+        return HttpResponse.json({ error: 'Not Found' }, { status: 404 });
+      }
+
+      if (result.error === 'FORBIDDEN') {
+        return HttpResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
+    return HttpResponse.json(result, { status: 200 });
+  }),
+
   http.post('/api/lost-items', async ({ request }) => {
     const formData = await request.formData();
     const result = createLostItemFromFormData(formData);

--- a/src/mocks/selectors/lostItems.selectors.ts
+++ b/src/mocks/selectors/lostItems.selectors.ts
@@ -79,3 +79,33 @@ export function getEtcDetail(
     description: targetLostItem.description ?? null,
   };
 }
+
+export function getPublicById(
+  lostItemId: number,
+):
+  | {
+      status: 'registered';
+      lostItemId: number;
+      categoryId: number;
+      categoryName: string;
+      foundLocation: string;
+      foundDate: string;
+      imageUrl: string;
+    }
+  | { error: 'NOT_FOUND' | 'FORBIDDEN' } {
+  const item = getLostItemById(lostItemId);
+  if (!item) return { error: 'NOT_FOUND' };
+  if (item.status !== 'registered') return { error: 'FORBIDDEN' };
+
+  const imageUrl =
+    item.categoryId === ETC_CATEGORY_ID ? item.imageUrl : categoryIcons[item.categoryId];
+  return {
+    status: 'registered',
+    lostItemId: item.lostItemId,
+    categoryId: item.categoryId,
+    categoryName: item.categoryName,
+    foundLocation: `${item.foundAreaName} ${item.detailLocation}`,
+    foundDate: item.foundDate,
+    imageUrl,
+  };
+}


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 필요한 제목을 복사 붙여넣기하여 사용해주세요!
		feat: 무슨 부분 기능 추가
		refactor: 무슨 부분 기능 개선
		docs: 무슨 문서 수정
		test: 무슨 테스트 추가
		chore: 잡일, 빌드, 설정 변경
-->

<!-- 기능 추가 -->
🔥 구현 기능
---
- 기존 모달 방식에서와 다르게 특정 분실물의 공개 정보에 바로 접근하는 경우 공개 정보에 대한 데이터를 제공하기 위해서 id를 통해 공개 정보 데이터를 받아오는 API 추가
- 추가적으로 found나 pledged 상태의 id에 대한 접근에 대하여 오류 처리 존재하지 않는 아이디에 대한 접근도 오류 처리    

🚧 작업목록
---
- [ ] 분실물 id를 통한 해당 분실물의 공개 정보(카테고리, 발견 날짜, 발견 장소) 접근을 위한 API
- [ ] 오류 처리에 대한 로직 구현(접근 불가능한 정보(id가 존재하지 않는 경우, 분실물의 상태가 found나 pledged 상태 인경우)


<!-- 기능 개선 -->
📝 현재 문제점
---

- 해당 엔드 포인트를 도입하면서 느낀건데 로그인 로직이 들어오게 되면 MSW와 API 호출 부에 대규모 수정이 생길 것 같습니다. 😭

🛠️ 해결 방안 
---

- 잠을 줄여가면서 야작하기🥱

<!-- 주석 해제하고 사용해주세요 (기능추가,기능개선 작성시 작성 하시면됩니다)
⚙️ 작업 내용
---
- 기능 구현에 필요한 작업 항목을 작성합니다.
- 예: API 설계, 프론트엔드 화면 구성 등.
-->


🙋‍♂️ 담당자
---
- **프론트엔드**: 박찬빈

Closes #61 
