### PR TITLE
fix #85: mainpage에서 영역 취소 시 selectedArea값이 남는 문제 해결

### DIFF
--- a/src/component/main/main/CategoryRadio.tsx
+++ b/src/component/main/main/CategoryRadio.tsx
@@ -21,7 +21,11 @@ const CategoryRadio = () => {
   // 카테고리 선택 시 페이지 1로 이동시키는 핸들러
   const handleSelectCategory = (id: number) => {
     const next = new URLSearchParams();
-    next.set('schoolAreaId', String(selectedAreaId) || '0');
+    if (selectedAreaId === 0) {
+      next.delete('schoolAreaId');
+    } else {
+      next.set('schoolAreaId', String(selectedAreaId));
+    }
     if (id === 0) {
       next.delete('categoryId');
     } else {

--- a/src/component/main/main/Map.tsx
+++ b/src/component/main/main/Map.tsx
@@ -48,6 +48,7 @@ const Map = () => {
     const next = new URLSearchParams();
     if (areaId === 0) {
       next.delete('schoolAreaId');
+      setSelectedAreaId(0);
     } else {
       next.set('schoolAreaId', String(areaId));
       setSelectedAreaId(areaId);


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 예시 입니다.
		hotfix: 무슨 버그 수정 필요
		fit: 무슨 버그 수정 필요		
-->

🚨 요약
---
<!-- 버그에 대한 간단하고 명확한 설명 -->

- 어떤 부분에서 버그가 발생했는지, 어떤 현상이 나타나는지 작성해주세요.

🔄 재현 방법
---
<!-- 버그를 재현하는 단계에 대한 자세한 설명 -->

1. 영역 클릭
2. 영역 취소
3. 카테고리 클릭
 -> 취소한 영역의 파라미터가 남아있음

📸 참고 자료
---
<img width="1470" height="956" alt="KakaoTalk_20250912_195728352" src="https://github.com/user-attachments/assets/e7b4073f-4d26-4bbe-80df-cba949120e98" />


❓ 이유
<!-- 버그가 발생한 이유에 대해 예상이 간다면 적어주세요. 모른다면 적지 않아도 됩니다. -->
영역 재클릭 선택/해제 시 ui에서 반영하기 위해 파라미터와 함께 `selectedAreaId` 상태를 함께 이용하여 영역을 관리하는데, 
selectedAreaId가 영역 취소 시 갱신 안됨


💡 제안
<!-- 버그를 해결하기 수정사항에 대해 설명해주세요. 모른다면 적지 않아도 됩니다. -->
갱신하도록 변경

추가로 selectedArea가 없을 시, 파라미터를 `schoolArea=0`이 아닌 제거하도록 변경


🔗 관련 링크
<!-- 기능과 관련해 참고할 링크가 있다면 적어주세요. 없다면 적지 않아도 됩니다. -->


🙋‍♂️ 담당자
---
- **백엔드**: 이름
- **프론트엔드**: 강동현
