### PR TITLE
fix #90: 라우팅 시 selectedArea상태 유지되는 문제 수정

### DIFF
--- a/src/component/main/main/Main.tsx
+++ b/src/component/main/main/Main.tsx
@@ -1,11 +1,16 @@
 import { useContext, useState } from 'react';
 import Map from './Map';
 import LostList from './list/LostList';
-import { SelectedModeContext, TotalCountContext } from '../../../contexts/AppContexts';
+import {
+  SelectedAreaIdContext,
+  SelectedModeContext,
+  TotalCountContext,
+} from '../../../contexts/AppContexts';
 import { useNavigate } from 'react-router-dom';
 
 const Main = () => {
   const { selectedMode, setSelectedMode } = useContext(SelectedModeContext)!;
+  const { setSelectedAreaId } = useContext(SelectedAreaIdContext)!;
   const [isMobileListOpen, setIsMobileListOpen] = useState(false);
   const { totalCount } = useContext(TotalCountContext)!;
 
@@ -14,6 +19,7 @@ const Main = () => {
   const handleRegisterButtonClick = () => {
     setSelectedMode(selectedMode === 'register' ? 'append' : 'register');
     const url = new URLSearchParams();
+    setSelectedAreaId(0);
     navigate({ search: `${url.toString()}` }, { replace: true });
   };
 

--- a/src/component/main/main/list/LostListItem.tsx
+++ b/src/component/main/main/list/LostListItem.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import type {
   ListItemComponentProps,
   StatusBadgeComponentProps,
 } from '../../../../types/main/components';
 import { useNavigate } from 'react-router-dom';
+import { SelectedAreaIdContext } from '../../../../contexts/AppContexts';
 
 // 분실물 등록 시간 포맷팅
 function formatKST(iso: string) {
@@ -36,6 +37,7 @@ export default function LostListItem({ item, className }: ListItemComponentProps
   const [imgError, setImgError] = useState(false);
 
   const navigate = useNavigate();
+  const { setSelectedAreaId } = useContext(SelectedAreaIdContext)!;
 
   return (
     <li className={`relative rounded-2xl bg-white p-4 shadow-sm ring-1 ring-black/5 ${className}`}>
@@ -69,7 +71,10 @@ export default function LostListItem({ item, className }: ListItemComponentProps
 
           <button
             className="absolute right-3 bottom-3 rounded-lg border border-teal-200 px-2.5 py-1 text-xs text-teal-700 hover:bg-teal-50"
-            onClick={() => navigate(`/find/${item.lostItemId}`)}
+            onClick={() => {
+              setSelectedAreaId(0);
+              navigate(`/find/${item.lostItemId}`);
+            }}
           >
             분실물 찾기
           </button>

--- a/src/component/main/modal/RegisterConfirmModal.tsx
+++ b/src/component/main/modal/RegisterConfirmModal.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   RegisterConfirmModalContext,
   SchoolAreasContext,
+  SelectedAreaIdContext,
   SelectedModeContext,
 } from '../../../contexts/AppContexts';
 
@@ -14,11 +15,12 @@ const RegisterConfirmModal = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { setSelectedMode } = useContext(SelectedModeContext)!;
-
+  const { setSelectedAreaId } = useContext(SelectedAreaIdContext)!;
   const selectedAreaId = Number(searchParams.get('schoolAreaId')) || 0;
   const { schoolAreas } = useContext(SchoolAreasContext)!;
 
   const handleCancel = () => {
+    setSelectedAreaId(0);
     navigate({ search: `?schoolAreaId=${0}` }, { replace: true });
     setSelectedMode('append');
     setIsRegisterConfirmModalOpen(false);
@@ -45,6 +47,7 @@ const RegisterConfirmModal = () => {
           <button
             className="rounded-lg bg-teal-600 px-4 py-2 text-white hover:bg-teal-700"
             onClick={() => {
+              setSelectedAreaId(0);
               setIsRegisterConfirmModalOpen(false);
               navigate(`/register/${selectedAreaId}`);
             }}


### PR DESCRIPTION
1. 찾기 프로세스 종료 시 해당 버그가 일어나는 상황을 고쳤습니다.
2. RegisterConfirmModal을 닫았을 시 해당 버그가 일어나는 상황을 고쳤습니다.

저번 pr은 부주의했네요.. 지적해주셔서 정말 감사합니다!!

디버깅하면서 느꼈는데, AreaId를 더 유지보수가 용이하게 관리할 수 있도록 리팩토링이 가능할 것 같습니다!
일단 감기부터 낫고 시간이 난다면 해당 작업 들어가 볼게요!

🙋‍♂️ 담당자
---
- **백엔드**: 이름
- **프론트엔드**: 강동현
