### PR TITLE
Refactor/#82 [분실물 등록] 카테고리 특징 API 호출 로직 변경

### DIFF
--- a/src/hooks/register/useRegisterLayout.ts
+++ b/src/hooks/register/useRegisterLayout.ts
@@ -38,8 +38,28 @@ export const useRegisterLayout = () => {
   };
 
   const goToNextStep = () => {
-    if (currentStep === 1) navigate('details');
-    if (currentStep === 2) navigate('review');
+    if (currentStep === 1) {
+      if (!registerProcess.selectedCategory) {
+        alert('카테고리를 선택해주세요.');
+        return;
+      }
+
+      navigate({
+        pathname: 'details',
+        search: `?categoryId=${registerProcess.selectedCategory.id}`,
+      });
+    }
+    if (currentStep === 2) {
+      if (!registerProcess.selectedCategory) {
+        alert('카테고리를 선택해주세요.');
+        return;
+      }
+
+      navigate({
+        pathname: 'review',
+        search: `?categoryId=${registerProcess.selectedCategory.id}`,
+      });
+    }
   };
 
   return {

--- a/src/hooks/register/useRegisterLayout.ts
+++ b/src/hooks/register/useRegisterLayout.ts
@@ -31,7 +31,7 @@ export const useRegisterLayout = () => {
   const goToPrevStep = () => {
     if (currentStep === 1) {
       setSelectedMode('append');
-      navigate('/');
+      navigate('/', { replace: true });
     }
     if (currentStep === 2) navigate('category');
     if (currentStep === 3) navigate('details');
@@ -44,10 +44,13 @@ export const useRegisterLayout = () => {
         return;
       }
 
-      navigate({
-        pathname: 'details',
-        search: `?categoryId=${registerProcess.selectedCategory.id}`,
-      });
+      navigate(
+        {
+          pathname: 'details',
+          search: `?categoryId=${registerProcess.selectedCategory.id}`,
+        },
+        { replace: true },
+      );
     }
     if (currentStep === 2) {
       if (!registerProcess.selectedCategory) {
@@ -55,10 +58,13 @@ export const useRegisterLayout = () => {
         return;
       }
 
-      navigate({
-        pathname: 'review',
-        search: `?categoryId=${registerProcess.selectedCategory.id}`,
-      });
+      navigate(
+        {
+          pathname: 'review',
+          search: `?categoryId=${registerProcess.selectedCategory.id}`,
+        },
+        { replace: true },
+      );
     }
   };
 

--- a/src/hooks/register/useRegisterProcess.ts
+++ b/src/hooks/register/useRegisterProcess.ts
@@ -130,7 +130,7 @@ export const useRegisterProcess = (schoolAreaIdArg?: number | null) => {
         buttonText: '홈으로',
         onConfirm: () => {
           setResultModalContent(null);
-          navigate('/');
+          navigate('/', { replace: true });
           setSelectedMode('append');
         },
       });
@@ -142,6 +142,8 @@ export const useRegisterProcess = (schoolAreaIdArg?: number | null) => {
         buttonText: '확인',
         onConfirm: () => {
           setResultModalContent(null);
+          navigate('/', { replace: true });
+          setSelectedMode('append');
         },
       });
     } finally {


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
- closed #82

## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

기존 방식은 카테고리 선택 단계에서 카테고리를 선택하면 해당 특징을 받아오는 API를 호출하는 로직이었습니다. 하지만, 이 방식은 다음 단계에서 브라우저를 새로고침하게 되면, 카테고리 특징이 사라지기 때문에 아래와 같은 방식으로 API 호출 로직을 변경하게 됐습니다.

변경된 방식은 카테고리 선택 단계에서 선택된 카테고리 ID를 Query String으로 추가하여 상세정보 단계 페이지로 넘어갑니다. 상세정보 단계 페이지에서는 Query String 값을 읽어 해당 카테고리에 알맞는 카테고리 특징을 fetch하여 렌더링 시킵니다. 위와 같은 방식으로 refactoring 하면, 브라우저 새로고침에도 카테고리 특징을 계속해서 가져올 수 있기 때문에 기존의 문제점을 해결할 수 있습니다.


## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
- 카테고리 특징 API 호출이 정상적으로 작동하는지
- 예외 상황은 없는지
- 테스트가 제대로 돌아가는지

## ✅ 테스트
- [x] useRegisterLayout.test.ts 수정 완료
- [x] useregisterProcess.test.ts 수정 완료