### PR TITLE
Fix/#114 찾기 페이지 버튼 위치가 화면에 맞게 고정되도록 수정 및 찾기 h1 요소 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/src/pages/find/FindDeposit.tsx
+++ b/src/pages/find/FindDeposit.tsx
@@ -51,7 +51,7 @@ export default function FindDeposit() {
         setLoading(false);
       }
     })();
-  }, [lostItemId, setAuthenticated, setUnauthenticated]);
+  }, [lostItemId, isAuthenticated, setAuthenticated, setUnauthenticated, navigate]);
 
   if (loading)
     return <div className="rounded-lg bg-gray-50 p-4 text-sm text-gray-500">불러오는 중…</div>;

--- a/src/pages/find/FindDetail.tsx
+++ b/src/pages/find/FindDetail.tsx
@@ -59,7 +59,7 @@ export default function FindDetail() {
         setLoading(false);
       }
     })();
-  }, [lostItemId, setAuthenticated, setUnauthenticated]);
+  }, [lostItemId, isAuthenticated, setAuthenticated, setUnauthenticated, navigate]);
 
   if (loading)
     return <div className="rounded-lg bg-gray-50 p-4 text-sm text-gray-500">불러오는 중…</div>;

--- a/src/pages/find/FindInfo.tsx
+++ b/src/pages/find/FindInfo.tsx
@@ -43,7 +43,7 @@ export default function FindInfo() {
         setLoading(false);
       }
     })();
-  }, [lostItemId]);
+  }, [lostItemId, navigate]);
 
   if (loading) return <div className="p-4 text-sm text-gray-500">불러오는 중…</div>;
   if (!item)

--- a/src/pages/find/FindLayout.tsx
+++ b/src/pages/find/FindLayout.tsx
@@ -100,7 +100,7 @@ export default function FindLayout() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
         <div className="relative flex h-[90vh] w-full max-w-4xl flex-col rounded-2xl bg-white p-6 lg:p-8">
           <h1 className="text-center text-2xl font-bold text-gray-800 md:text-3xl">분실물 찾기</h1>
           <div className="mt-6 rounded-lg bg-gray-50 p-4 text-center text-sm text-gray-500">
@@ -112,15 +112,15 @@ export default function FindLayout() {
   }
 
   return (
-    <main className="flex items-center justify-center">
-      <div className="relative flex h-[90vh] w-full max-w-4xl flex-col rounded-2xl bg-white p-6 lg:p-8">
+    <main className="flex items-center justify-center pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+      <div className="relative flex h-[90vh] w-full max-w-4xl flex-col rounded-2xl bg-white p-6 pb-10 lg:p-8 lg:pb-12">
         <h1 className="text-center text-2xl font-bold text-gray-800 md:text-3xl">{pageTitle}</h1>
 
         <div className="mt-3">
           <ProgressBar steps={stepLabels} currentStep={currentStepNumber} />
         </div>
 
-        <div className="mt-4 flex-grow overflow-y-auto pr-2 sm:pr-4">
+        <div className="mt-4 flex-grow overflow-y-auto pr-2 pb-3 sm:pr-3 md:pb-4">
           <Outlet context={{ setNextButtonValidator }} />
         </div>
 

--- a/src/pages/find/FindLayout.tsx
+++ b/src/pages/find/FindLayout.tsx
@@ -6,7 +6,6 @@ import {
   FIND_STEPS,
   NON_VALUABLE_FLOW,
   VALUABLE_FLOW,
-  PAGE_TITLES,
   ETC_CATEGORY_ID,
   NEXT_BUTTON_LABEL,
 } from '../../constants/find';
@@ -30,7 +29,6 @@ export default function FindLayout() {
   const currentStepIndex = Math.max(0, stepFlow.indexOf(currentRouteSegment));
   const currentStepNumber = currentStepIndex + 1;
   const currentStepKey: StepKey = stepFlow[currentStepIndex] ?? 'info';
-  const pageTitle = PAGE_TITLES[currentStepKey];
   const nextButtonLabel = NEXT_BUTTON_LABEL[currentStepKey];
 
   useEffect(() => {
@@ -102,7 +100,9 @@ export default function FindLayout() {
     return (
       <div className="flex items-center justify-center pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
         <div className="relative flex h-[90vh] w-full max-w-4xl flex-col rounded-2xl bg-white p-6 lg:p-8">
-          <h1 className="text-center text-2xl font-bold text-gray-800 md:text-3xl">분실물 찾기</h1>
+          <h1 className="text-center text-2xl font-normal text-gray-800 md:text-3xl">
+            분실물 찾기
+          </h1>
           <div className="mt-6 rounded-lg bg-gray-50 p-4 text-center text-sm text-gray-500">
             로딩 중…
           </div>
@@ -114,7 +114,7 @@ export default function FindLayout() {
   return (
     <main className="flex items-center justify-center pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <div className="relative flex h-[90vh] w-full max-w-4xl flex-col rounded-2xl bg-white p-6 pb-10 lg:p-8 lg:pb-12">
-        <h1 className="text-center text-2xl font-bold text-gray-800 md:text-3xl">{pageTitle}</h1>
+        <h1 className="text-center text-2xl font-normal text-gray-800 md:text-3xl">분실물 찾기</h1>
 
         <div className="mt-3">
           <ProgressBar steps={stepLabels} currentStep={currentStepNumber} />

--- a/src/pages/find/FindLayout.tsx
+++ b/src/pages/find/FindLayout.tsx
@@ -63,7 +63,7 @@ export default function FindLayout() {
     return () => {
       alive = false;
     };
-  }, [lostItemId]);
+  }, [lostItemId, navigate]);
 
   const nextButtonValidatorRef = useRef<NextButtonValidator | null>(null);
   const setNextButtonValidator = useCallback<FindOutletContext['setNextButtonValidator']>(

--- a/src/pages/find/FindPledge.tsx
+++ b/src/pages/find/FindPledge.tsx
@@ -57,7 +57,14 @@ export default function FindPledge() {
       }
     });
     return () => setNextButtonValidator(null);
-  }, [lostItemId, setNextButtonValidator]);
+  }, [
+    lostItemId,
+    setNextButtonValidator,
+    isAuthenticated,
+    setAuthenticated,
+    setUnauthenticated,
+    navigate,
+  ]);
 
   return (
     <div className="mx-auto max-w-2xl space-y-4">

--- a/src/pages/find/FindQuiz.tsx
+++ b/src/pages/find/FindQuiz.tsx
@@ -56,7 +56,7 @@ export default function FindQuiz() {
         setLoading(false);
       }
     })();
-  }, [lostItemId, isAuthenticated]);
+  }, [lostItemId, isAuthenticated, setAuthenticated, setUnauthenticated, navigate]);
 
   useEffect(() => {
     setNextButtonValidator(async () => {
@@ -109,7 +109,16 @@ export default function FindQuiz() {
     });
 
     return () => setNextButtonValidator(null);
-  }, [quiz, answers, lostItemId, setNextButtonValidator]);
+  }, [
+    quiz,
+    answers,
+    lostItemId,
+    setNextButtonValidator,
+    isAuthenticated,
+    setAuthenticated,
+    setUnauthenticated,
+    navigate,
+  ]);
 
   if (loading)
     return <div className="rounded-lg bg-gray-50 p-4 text-sm text-gray-500">퀴즈 불러오는 중…</div>;


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 필요한 제목을 복사 붙여넣기하여 사용해주세요!
		feat: 무슨 부분 기능 추가
		refactor: 무슨 부분 기능 개선
		docs: 무슨 문서 수정
		test: 무슨 테스트 추가
		chore: 잡일, 빌드, 설정 변경
-->

<!-- 기능 추가 -->
🔥 구현 기능
---
- `index.html에 env(safe-area-inset)가 잘 동작하고록 viewport-fit=cover요소 추가 및 env(safe-area-inset)를 활용하여 layout 위치 고정
- 의존성 배열에 빠져있던 의존성 추가
- 분실물 단계를 보여주던 h1요소의 텍스트 및 굵기 수정

🚧 작업목록
---
- `index.html에 env(safe-area-inset)가 잘 동작하고록 viewport-fit=cover요소 추가 및 env(safe-area-inset)를 활용하여 layout 위치 고정
- 의존성 배열에 빠져있던 의존성 추가 
- 분실물 단계를 보여주던 `h1`요소의 텍스트 및 굵기 수정 


<!-- 기능 개선 -->
📝 현재 문제점
---

- 특정 기능이 부족하거나 개선이 필요한 이유를 작성해주세요.

🛠️ 해결 방안 
---

- 문제를 해결하기 위한 구체적인 방안을 작성해주세요.
- 새로운 기능 또는 개선 사항에 대한 설명을 작성해주세요.

<!-- 주석 해제하고 사용해주세요 (기능추가,기능개선 작성시 작성 하시면됩니다)
⚙️ 작업 내용
---
- 기능 구현에 필요한 작업 항목을 작성합니다.
- 예: API 설계, 프론트엔드 화면 구성 등.
-->


🙋‍♂️ 담당자
---
- **프론트엔드**: 박찬빈

closes #114 