### PR TITLE
fix/#125 useCallback으로 참조 안정화하여 useEffect 중복 호출 방지 

### DIFF
--- a/src/contexts/AuthFlag.tsx
+++ b/src/contexts/AuthFlag.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useCallback, useState } from 'react';
 
 type AuthContextValue = {
   isAuthenticated: boolean; // 현재 탭의 UI 구성을 위한 로그인 상태 관리 프론트엔드에서는 확실한 로그인 여부를 확인이 불가하므로 해당 값은 UI적 용도임
@@ -52,22 +52,20 @@ export function AuthFlagProvider({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener('storage', handleStorage); // 언마운트시 이벤트 리스너를 해제하기 위해서
   }, []);
 
-  const value = useMemo<AuthContextValue>(
-    () => ({
-      isAuthenticated,
-      setAuthenticated: () => {
-        setIsAuthenticated(true);
-        writeAuthFlag(true);
-      },
-      setUnauthenticated: () => {
-        setIsAuthenticated(false);
-        writeAuthFlag(false);
-      },
-    }),
-    [isAuthenticated],
-  );
+  const setAuthenticated = useCallback(() => {
+    setIsAuthenticated(true);
+    writeAuthFlag(true);
+  }, []);
+  const setUnauthenticated = useCallback(() => {
+    setIsAuthenticated(false);
+    writeAuthFlag(false);
+  }, []);
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, setAuthenticated, setUnauthenticated }}>
+      {children}
+    </AuthContext.Provider>
+  );
 }
 
 export function useAuthFlag() {


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 예시 입니다.
		hotfix: 무슨 버그 수정 필요
		fit: 무슨 버그 수정 필요		
-->

🚨 요약
---
<!-- 버그에 대한 간단하고 명확한 설명 -->

- 일전의 의존성 배열에 setter 함수를 추가해주면서 setter 함수의 참조가 로그인 여부 flag값에 따라 변경되어 중복 호출되던 문제

🔄 재현 방법
---
<!-- 버그를 재현하는 단계에 대한 자세한 설명 -->

1. 로그인을 하지 않고 분실물 찾기 페이지로 이동
2. 물건 정보 창에서 다음 버튼을 클릭
3. 로그인에 대한 경고가 2번 뜨는 것을 확인 할 수 있음 

📸 참고 자료
---
<!-- 스크린샷(버그이미지, 코드이미지), 에러로그를 적어주세요. 없다면 적지 않아도 됩니다.-->

<오류 영상>
https://github.com/user-attachments/assets/ab9b2aeb-1aa6-46b3-9c47-eb2c735e8a73

<해결 영상>
https://github.com/user-attachments/assets/f45d2407-45a5-4c74-ab22-8ff35d3d5f0b


💡 해결 방안 
---
useCallback을 통해 setter 함수의 참조값을 안정화 시키면 중복 호출을 막을 수 있다.


🙋‍♂️ 담당자
---
- **프론트엔드**: 박찬빈

closes #125 