### PR TITLE
fix: MainPage 분실물 추가 모드에서 zindex가 낮아 pagenation이 가려지지 않는 문제 수정 #130

### DIFF
--- a/src/component/main/main/Main.tsx
+++ b/src/component/main/main/Main.tsx
@@ -34,7 +34,7 @@ const Main = () => {
         <section className="relative h-full min-h-0 min-w-0">
           <Map />
           <button
-            className="absolute bottom-[calc(1.25rem+env(safe-area-inset-bottom))] left-1/2 z-30 block -translate-x-1/2 rounded-full bg-teal-600 px-4 py-3 text-sm text-white shadow-lg hover:bg-teal-700 md:hidden"
+            className="fixed bottom-[calc(1.25rem+env(safe-area-inset-bottom))] left-1/2 z-30 block -translate-x-1/2 rounded-full bg-teal-600 px-4 py-3 text-sm text-white shadow-lg hover:bg-teal-700 md:hidden"
             onClick={() => setIsMobileListOpen(true)}
           >
             분실물
@@ -43,7 +43,7 @@ const Main = () => {
           </button>
 
           <div
-            className={`absolute inset-0 z-40 flex transform flex-col bg-white transition-transform duration-300 ease-out md:hidden ${
+            className={`fixed inset-0 z-40 flex transform flex-col bg-white transition-transform duration-300 ease-out md:hidden ${
               isMobileListOpen ? 'translate-y-0' : 'pointer-events-none translate-y-full'
             }`}
           >
@@ -63,7 +63,7 @@ const Main = () => {
           </div>
 
           <button
-            className="absolute right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-30 rounded-full bg-teal-600 px-4 py-3 text-sm text-white shadow-lg hover:bg-teal-700 md:bottom-[calc(9rem+env(safe-area-inset-bottom))]"
+            className="fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-30 rounded-full bg-teal-600 px-4 py-3 text-sm text-white shadow-lg hover:bg-teal-700 ]"
             onClick={handleRegisterButtonClick}
           >
             {selectedMode === 'register' ? '분실물 조회' : '분실물 추가'}

--- a/src/component/main/main/Main.tsx
+++ b/src/component/main/main/Main.tsx
@@ -29,7 +29,7 @@ const Main = () => {
         <aside className="relative hidden h-full border-r md:block">
           <LostList />
 
-          {selectedMode === 'register' && <div className="absolute inset-0 z-10 bg-gray-500/30" />}
+          {selectedMode === 'register' && <div className="absolute inset-0 z-70 bg-gray-500/30" />}
         </aside>
         <section className="relative h-full min-h-0 min-w-0">
           <Map />

--- a/src/component/main/main/Map.tsx
+++ b/src/component/main/main/Map.tsx
@@ -115,7 +115,7 @@ const Map = () => {
       )}
 
       {hoverArea && (
-        <div className="absolute bottom-[calc(1.25rem+env(safe-area-inset-bottom))] left-3 z-10 hidden rounded-md bg-white/90 px-6 py-2 text-base shadow md:bottom-[calc(9rem+env(safe-area-inset-bottom))] md:block">
+        <div className="fixed bottom-[calc(1.25rem+env(safe-area-inset-bottom))] left-100 z-10 hidden rounded-md bg-white/90 px-6 py-2 text-base shadow md:block">
           {hoverArea?.areaName}
         </div>
       )}


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 예시 입니다.
		hotfix: 무슨 버그 수정 필요
		fit: 무슨 버그 수정 필요		
-->

🚨 요약
---
<!-- 버그에 대한 간단하고 명확한 설명 -->

MainPage 분실물 추가 모드에서 zindex가 낮아 pagenation이 가려지지 않는 문제 수정
 
🔄 재현 방법
---
<!-- 버그를 재현하는 단계에 대한 자세한 설명 -->

1. 문제 발생 위치로 이동 (예: 특정 페이지 또는 기능)
2. 특정 동작 수행 (예: 버튼 클릭, 데이터 입력 등)
3. 버그가 발생한 결과 확인

📸 참고 자료
---
<!-- 스크린샷(버그이미지, 코드이미지), 에러로그를 적어주세요. 없다면 적지 않아도 됩니다.-->

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/2cabc058-18ac-4795-b3d6-8dc5ba3ce520" />

❓ 이유
<!-- 버그가 발생한 이유에 대해 예상이 간다면 적어주세요. 모른다면 적지 않아도 됩니다. -->

💡 제안
<!-- 버그를 해결하기 수정사항에 대해 설명해주세요. 모른다면 적지 않아도 됩니다. -->

🔗 관련 링크
<!-- 기능과 관련해 참고할 링크가 있다면 적어주세요. 없다면 적지 않아도 됩니다. -->


🙋‍♂️ 담당자
---
- **백엔드**: 이름
- **프론트엔드**: 이름


===

close