### PR TITLE
refactor#163: 목록 크기 변경

### DIFF
--- a/src/component/main/main/Main.tsx
+++ b/src/component/main/main/Main.tsx
@@ -38,8 +38,8 @@ const Main = () => {
             }`}
           >
             <div className="flex items-center justify-between border-b px-4 py-3">
-              <h3 className="text-sm font-semibold">분실물 목록</h3>
-              <p>총 {totalCount}건</p>
+              <h3 className="text-lg font-semibold">분실물 목록</h3>
+              <p className="text-lg text-gray-500">총 {totalCount}건</p>
               <button
                 className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
                 onClick={() => setIsMobileListOpen(false)}

--- a/src/component/main/main/list/LostList.tsx
+++ b/src/component/main/main/list/LostList.tsx
@@ -21,7 +21,7 @@ export default function LostList() {
     <div className="flex min-h-0 flex-1 flex-col px-4 py-4 md:h-[100dvh] md:overflow-hidden">
       <div className="relative hidden md:block">
         <h2 className="mb-2 text-lg font-semibold text-teal-700">분실물 목록</h2>
-        <div className="text-md mb-3 text-gray-500">총 {totalCount}개</div>
+        <div className="mb-3 text-base text-gray-500">총 {totalCount}개</div>
       </div>
 
       <div


### PR DESCRIPTION
closed #163 

---

before

<img width="1912" height="909" alt="스크린샷 2025-11-27 221327" src="https://github.com/user-attachments/assets/31e090ce-c7c0-47fd-bd28-804adf636bcd" />

after

<img width="1911" height="901" alt="스크린샷 2025-11-27 222450" src="https://github.com/user-attachments/assets/82589da3-92f2-4cce-8d9c-d198a5a5ba47" />

<img width="382" height="821" alt="image" src="https://github.com/user-attachments/assets/002d6389-336b-4c7b-a99e-ed4657c54d8e" />

