### PR TITLE
refactor/#185 분실물 목록 아이콘 변경

### DIFF
--- a/src/component/main/main/list/LostListItem.tsx
+++ b/src/component/main/main/list/LostListItem.tsx
@@ -6,8 +6,20 @@ import type {
 import { useNavigate } from 'react-router-dom';
 import { SelectedAreaIdContext } from '../../../../contexts/AppContexts';
 import { COMMON_BUTTON_CLASSNAME } from '../../../../constants/common';
+import {
+  Smartphone,
+  Briefcase,
+  CreditCard,
+  IdCard,
+  IdCardLanyard,
+  Wallet,
+  Gem,
+  Tablet,
+  Laptop,
+  Headphones,
+  Ellipsis,
+} from 'lucide-react';
 
-// 분실물 등록 시간 포맷팅
 function formatKST(iso: string) {
   try {
     return new Date(iso).toLocaleDateString('ko-KR', {
@@ -20,7 +32,48 @@ function formatKST(iso: string) {
   }
 }
 
-// 분실물 상태 배지
+const getCategoryIcon = (categoryName: string) => {
+  const trimmedCategoryName = categoryName.trim();
+
+  switch (trimmedCategoryName) {
+    case '핸드폰':
+      return Smartphone;
+
+    case '가방':
+      return Briefcase;
+
+    case '결제 카드':
+      return CreditCard;
+
+    case 'ID 카드':
+      return IdCard;
+
+    case '기숙사 카드':
+      return IdCardLanyard;
+
+    case '지갑':
+      return Wallet;
+
+    case '액세서리':
+      return Gem;
+
+    case '패드':
+      return Tablet;
+
+    case '노트북':
+      return Laptop;
+
+    case '전자 음향기기':
+      return Headphones;
+
+    case '기타':
+    default:
+      return Ellipsis;
+  }
+};
+
+const isEtcCategory = (name: string) => name.trim() === '기타';
+
 function StatusBadge({ status }: StatusBadgeComponentProps) {
   const isFound = status === 'found';
   const badgeClass = isFound
@@ -34,26 +87,30 @@ function StatusBadge({ status }: StatusBadgeComponentProps) {
 }
 
 export default function LostListItem({ item, className }: ListItemComponentProps) {
-  // 이미지 로딩 에러 처리
   const [imgError, setImgError] = useState(false);
 
   const navigate = useNavigate();
   const { setSelectedAreaId } = useContext(SelectedAreaIdContext)!;
 
+  const etcCategory = isEtcCategory(item.categoryName);
+  const CategoryIcon = getCategoryIcon(item.categoryName);
+
   return (
     <li className={`relative rounded-2xl bg-white p-4 shadow-sm ring-1 ring-black/5 ${className}`}>
       <div className="flex gap-2">
-        {item.imageUrl && !imgError ? (
-          <img
-            src={item.imageUrl}
-            alt={item.categoryName}
-            className="h-16 w-16 shrink-0 rounded-xl bg-teal-50 object-cover"
-            onError={() => setImgError(true)}
-            loading="lazy"
-          />
-        ) : (
-          <div className="h-16 w-16 shrink-0 rounded-xl bg-teal-50" />
-        )}
+        <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-teal-50">
+          {etcCategory && item.imageUrl && !imgError ? (
+            <img
+              src={item.imageUrl}
+              alt={item.categoryName}
+              className="h-full w-full object-cover"
+              onError={() => setImgError(true)}
+              loading="lazy"
+            />
+          ) : (
+            <CategoryIcon className="h-11 w-11 text-teal-700" aria-hidden="true" />
+          )}
+        </div>
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">


### PR DESCRIPTION
<!--📚 GitHub 이슈 작성 템플릿 -->
<!-- 필요한 제목을 복사 붙여넣기하여 사용해주세요!
		refactor: 무슨 부분 기능 개선 요청
-->

🔨 리팩토링 기능
---
<!-- 리팩토링 요청에 대한 간략한 설명을 적어주세요. -->
기존의 서버에서 주는 아이콘의 통일성을 보완하기 위해서 일단은 프론트엔드단에서 카테고리 값에 따라 `lucide-react` 아이콘 값으로 매핑 시키도록 수정

📖 리팩토링 내용
---
<!-- 어떻게 수정했으면 좋겠는지 자세하게 적어주세요. 최대한 자세할수록 좋습니다. -->

바뀐 서비스 톤에 맞게 통일성 있는 `lucide-react` 아이콘으로 수정
(추후에 서버에 해당 아이콘 URL을 넘겨서 띄우는 방식으로 변경 필요)

[수정전]
<img width="750" height="1182" alt="image" src="https://github.com/user-attachments/assets/10b51e8d-5b7b-4aa2-8e20-22bd5c456994" />

[수정후]
<img width="812" height="1336" alt="image" src="https://github.com/user-attachments/assets/a19eea2d-d6e9-4304-baa0-2ec37aa8c237" />


🚧 작업 목록
---
<!-- 리팩토링을 위한 수행 작업 목록을 작성해주세요. 최대한 자세할수록 좋습니다. -->
- [x] 가져온 분실물 카테고리에 따라 `lucide-react` 아이콘 매핑
- [x] 카테고리가 기타인 경우 가져온 이미지 URL로 매핑

🔗 관련 링크
---
<!-- 기능과 관련해 참고할 링크가 있다면 적어주세요. 없다면 적지 않아도 됩니다. -->


🙋‍♂️ 담당자
---
- **프론트엔드**: 박찬빈

closed #185 
