### PR TITLE
fix/#189 서버 카테고리명 변경에 따른 음향기기 아이콘 매핑 수정

### DIFF
--- a/src/pages/register/RegisterCategory.tsx
+++ b/src/pages/register/RegisterCategory.tsx
@@ -46,6 +46,7 @@ const getCategoryIcon = (name: string) => {
     case '노트북':
       return Laptop;
 
+    case '전자 음향기기':
     case '음향기기':
       return Headphones;
 


### PR DESCRIPTION
🔨 리팩토링 기능
---
서버에서 내려오는 카테고리명 변경에 따른 아이콘 매핑 로직 개선


📖 리팩토링 내용
---
기존 `전자 음향기기` 카테고리명을 기준으로 아이콘을 매핑하던 로직에  
변경된 카테고리명인 `음향기기`도 함께 처리하도록 분기 조건을 추가합니다.

🚧 작업 목록
---
- [x] `getCategoryIcon` 함수에 `음향기기` 케이스 추가

**[수정 전]**
<img width="2560" height="1322" alt="Image" src="https://github.com/user-attachments/assets/ba0382bc-c1ee-4e53-9586-37c57d820091" />
**[수정후]**
<img width="2560" height="1326" alt="image" src="https://github.com/user-attachments/assets/f6b1f297-5bd9-4a2d-be12-7e8620e37aef" />


🔗 관련 링크
---


🙋‍♂️ 담당자
---
- **프론트엔드**: 박찬빈

closed #189 