### PR TITLE
FIX: 최종 분실물 등록 버튼을 여러 번 누르는 버그 수정

### DIFF
--- a/src/hooks/register/useRegisterProcess.ts
+++ b/src/hooks/register/useRegisterProcess.ts
@@ -23,6 +23,7 @@ export const useRegisterProcess = (schoolAreaIdArg?: number | null) => {
   const { formData, setField, setImages, setFeature, resetForm } =
     useRegisterState(validSchoolAreaId);
 
+  const [isPending, setIsPending] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
   const [resultModalContent, setResultModalContent] = useState<ResultModalContent | null>(null);
   const [schoolAreas, setSchoolAreas] = useState<SchoolArea[]>([]);
@@ -81,6 +82,8 @@ export const useRegisterProcess = (schoolAreaIdArg?: number | null) => {
       description: formData.description || undefined,
     };
 
+    setIsPending(true);
+
     try {
       await postLostItem(requestData, formData.images);
       resetForm();
@@ -108,11 +111,14 @@ export const useRegisterProcess = (schoolAreaIdArg?: number | null) => {
           setSelectedMode('register');
         },
       });
+    } finally {
+      setIsPending(false);
     }
   };
 
   return {
     isLoading,
+    isPending,
     schoolAreas,
     categories,
     selectedCategory,

--- a/src/pages/register/RegisterLayout.tsx
+++ b/src/pages/register/RegisterLayout.tsx
@@ -14,6 +14,7 @@ const RegisterLayout = () => {
     currentStep,
     resultModalContent,
     isLoading,
+    isPending,
     selectedCategory,
     isStep2Valid,
     goToPrevStep,
@@ -58,7 +59,7 @@ const RegisterLayout = () => {
             ) : (
               <button
                 onClick={handleRegister}
-                disabled={isLoading}
+                disabled={isLoading || isPending}
                 className={`${COMMON_BUTTON_CLASSNAME} ${LAYOUT_BUTTON_CLASSNAME} bg-teal-500 text-white hover:bg-teal-600 focus-visible:ring-teal-300 disabled:cursor-not-allowed disabled:bg-gray-300`}
               >
                 {isLoading ? <SpinnerIcon /> : '등록하기'}


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
- closed #191 

## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

- `useRegisterProcess` 커스텀 훅에 `isPending` 이라는 분실물 등록 중이라는 상태 값을 추가하여, 분실물이 등록 중에는 버튼이 활성화 되지 않도록 변경하였습니다.
- 테스트 코드는 수정할 사항이 없어서 수정하지 않았습니다.


## 📸 실행 영상
아래의 영상처럼 분실물 정보를 입력하고, 등록하기 버튼을 2번 클릭했는데 DB에는 1가지 분실물만 들어간 것을 확인할 수 있습니다.


https://github.com/user-attachments/assets/2c35e478-6386-4b47-9569-40911aa1061e



## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  

- 현재 서버 설정이 5173, 4173 개발 포트가 막혀있어 저도 개인 로컬 서버를 띄워서 분실물이 1가지만 들어가는지 체크했었습니다.
- 테스트 해보실 분들은 BE 레포 clone 받고 설정을 해야 가능할 것 같네요..